### PR TITLE
Move assert.js out of functions and into core

### DIFF
--- a/src/core/assert.js
+++ b/src/core/assert.js
@@ -1,4 +1,8 @@
-import {isFunction, isUndefined} from "../core/types";
+import {asSequence} from "./asSequence";
+import {isSequence} from "./sequence";
+import {isArray, isFunction, isUndefined} from "./types";
+
+import {equals} from "../functions/equals";
 
 const assertMessage = (message, value) => (isFunction(message) ?
     message(value) : (message || "Assertion error")
@@ -12,6 +16,7 @@ export const AssertError = function(message, value = undefined){
 AssertError.prototype = Object.create(Error.prototype);
 AssertError.prototype.constructor = AssertError;
 
+// Throw an error if the condition isn't met.
 export const assert = function(condition, message = undefined){
     if(!condition) throw new AssertError(
         assertMessage(message, condition), condition
@@ -19,6 +24,7 @@ export const assert = function(condition, message = undefined){
     return condition;
 };
 
+// Throw an error if the condition is met.
 export const assertNot = function(condition, message = undefined){
     if(condition) throw new AssertError(
         assertMessage(message, condition), condition
@@ -26,6 +32,7 @@ export const assertNot = function(condition, message = undefined){
     return condition;
 };
 
+// Throw an error if the input value isn't undefined.
 export const assertUndefined = function(value, message = undefined){
     if(!isUndefined(value)) throw new AssertError(
         assertMessage(message, value), value
@@ -33,6 +40,7 @@ export const assertUndefined = function(value, message = undefined){
     return value;
 };
 
+// Throw an error if all the given values aren't equal.
 export const assertEqual = function(...values){
     for(let i = 1; i < values.length; i++){
         if(values[i] !== values[0]) throw new AssertError(
@@ -40,6 +48,22 @@ export const assertEqual = function(...values){
         );
     }
     return values[0];
+};
+
+// Throw an error if the elements of two sequences aren't equal.
+// Compares elements recursively, i.e. if the inputs are sequences of sequences
+// then those corresponding contained sequences are checked for equality, too.
+export const assertSeqEqual = function(sequenceA, sequenceB){
+    const compare = (a, b) => {
+        if(isSequence(a) || isSequence(b) || isArray(a) || isArray(b)){
+            return equals.implementation(compare, [
+                asSequence(a), asSequence(b)
+            ]);
+        }else{
+            return a === b;
+        }
+    };
+    return compare(sequenceA, sequenceB);
 };
 
 export default assert;

--- a/src/higher.js
+++ b/src/higher.js
@@ -71,13 +71,14 @@ hi.sequence.IterableSequence = IterableSequence;
 
 // Assertions
 import {
-    AssertError, assert, assertNot, assertUndefined, assertEqual
-} from "./functions/assert";
+    AssertError, assert, assertNot, assertUndefined, assertEqual, assertSeqEqual
+} from "./core/assert";
 hi.error.AssertError = AssertError;
 hi.assert = assert;
 hi.assertNot = assertNot;
 hi.assertUndefined = assertUndefined;
 hi.assertEqual = assertEqual;
+hi.assertSeqEqual = assertSeqEqual;
 
 // Function registry
 import {any} from "./functions/any"; hi.register(any);


### PR DESCRIPTION
Organizational improvement

Before this change `assert.js` was the only thing in `src/functions/` that didn't have wrapped functions etc.