### PR TITLE
All sequences now have their own unbounded methods

### DIFF
--- a/src/core/sequence.js
+++ b/src/core/sequence.js
@@ -50,10 +50,6 @@ Sequence.prototype.nextBack = function(){
     this.popBack();
     return value;
 };
-// TODO: Make this part of normal sequence spec just like bounded
-Sequence.prototype.unbounded = function(){
-    return this.source ? this.source.unbounded() : false;
-};
 Sequence.prototype.maskAbsentMethods = function(source){
     if(!source.back){
         this.back = null;

--- a/src/functions/flatten.js
+++ b/src/functions/flatten.js
@@ -28,6 +28,7 @@ export const ForwardFlattenSequence = Sequence.extend({
         };
     },
     bounded: () => false,
+    unbounded: () => false,
     done: function(){
         this.initialize();
         return this.frontSource.done();
@@ -76,6 +77,7 @@ export const BackwardFlattenSequence = Sequence.extend({
         };
     },
     bounded: () => false,
+    unbounded: () => false,
     done: function(){
         this.initialize();
         return this.frontSource.done();

--- a/src/functions/flattenDeep.js
+++ b/src/functions/flattenDeep.js
@@ -58,6 +58,7 @@ export const FlattenDeepSequence = Sequence.extend({
         };
     },
     bounded: () => false,
+    unbounded: () => false,
     done: function(){
         return this.sourceStack[0].done();
     },

--- a/src/functions/from.js
+++ b/src/functions/from.js
@@ -44,6 +44,14 @@ export const FromSequence = Sequence.extend({
     bounded: function(){
         return this.source.bounded();
     },
+    // This holds if the predicate matches any element.
+    // If it doesn't match any element then attempting to initialize this
+    // sequence will produce an infinite loop, so I think this is a safe
+    // assumption to make; users should not be producing that situation in the
+    // first place.
+    unbounded: function(){
+        return this.source.unbounded();
+    },
     done: function(){
         return this.source.done();
     },

--- a/src/functions/head.js
+++ b/src/functions/head.js
@@ -12,6 +12,7 @@ export const HeadSequence = Sequence.extend({
         this.maskAbsentMethods(source);
     },
     bounded: () => true,
+    unbounded: () => false,
     done: function(){
         return this.frontIndex >= this.elements || this.source.done();
     },

--- a/src/functions/ngrams.js
+++ b/src/functions/ngrams.js
@@ -16,6 +16,9 @@ export const NgramSequence = Sequence.extend({
     bounded: function(){
         return this.source.bounded();
     },
+    unbounded: function(){
+        return this.source.unbounded();
+    },
     done: function(){
         return this.source.done() && this.currentNgram.length < this.ngramSize;
     },

--- a/src/functions/one.js
+++ b/src/functions/one.js
@@ -25,6 +25,7 @@ export const OneElementSequence = Sequence.extend({
         return this;
     },
     bounded: () => true,
+    unbounded: () => false,
     done: function(){
         return this.isDone;
     },

--- a/src/functions/pad.js
+++ b/src/functions/pad.js
@@ -15,6 +15,9 @@ export const PadLeftSequence = Sequence.extend({
     bounded: function(){
         return this.source.bounded();
     },
+    unbounded: function(){
+        return this.source.unbounded();
+    },
     done: function(){
         return this.padCount >= this.padTotal && this.source.done();
     },
@@ -97,6 +100,10 @@ export const PadRightSequence = Sequence.extend({
     },
     bounded: function(){
         return this.source.bounded();
+    },
+    // Please don't right-pad unbounded sequences that doesn't make any sense
+    unbounded: function(){
+        return this.source.unbounded();
     },
     done: function(){
         return this.padCount >= this.padTotal && this.source.done();
@@ -209,7 +216,8 @@ Object.assign(SequencePadder.prototype, {
         }
     },
     rightCount: function(count, element){
-        return count <= 0 ? source : new PadRightSequence(
+        if(this.source.unbounded()) return source;
+        else return count <= 0 ? source : new PadRightSequence(
             this.source, element, count
         );
     },

--- a/src/functions/range.js
+++ b/src/functions/range.js
@@ -19,6 +19,7 @@ export const NumberRangeSequence = Sequence.extend({
         );
     },
     bounded: () => true,
+    unbounded: () => false,
     done: function(){
         return this.frontValue > this.backValue;
     },
@@ -77,6 +78,7 @@ export const ForwardNumberRangeSequence = Sequence.extend({
         );
     },
     bounded: () => true,
+    unbounded: () => false,
     done: function(){
         return this.frontValue > this.backValue;
     },
@@ -139,6 +141,7 @@ export const BackwardNumberRangeSequence = Sequence.extend({
         );
     },
     bounded: () => true,
+    unbounded: () => false,
     done: function(){
         return this.frontValue < this.backValue;
     },

--- a/src/functions/recur.js
+++ b/src/functions/recur.js
@@ -16,8 +16,8 @@ export const RecurSequence = Sequence.extend({
         this.frontValue = value;
         return this;
     },
-    unbounded: () => true,
     bounded: () => false,
+    unbounded: () => true,
     done: () => false,
     length: null,
     left: null,

--- a/src/functions/repeat.js
+++ b/src/functions/repeat.js
@@ -34,6 +34,10 @@ export const FiniteRepeatSequence = Sequence.extend({
     bounded: function(){
         return this.source.bounded();
     },
+    // Please don't repeat an already unbounded sequence
+    unbounded: function(){
+        return this.source.unbounded();
+    },
     done: function(){
         return (
             this.source.done() || (
@@ -168,8 +172,8 @@ export const InfiniteRepeatSequence = Sequence.extend({
         this.maskAbsentMethods(source);
     },
     repetitions: Infinity,
-    unbounded: () => true,
     bounded: () => false,
+    unbounded: () => true,
     done: () => false,
     length: null,
     left: null,
@@ -243,7 +247,7 @@ export const repeat = wrap({
         }
     },
     implementation: (repetitions, source) => {
-        if(repetitions <= 0 && repetitions !== null){
+        if(repetitions <= 0){
             return new EmptySequence();
         }else if(source.unbounded()){
             return source;

--- a/src/functions/repeatElement.js
+++ b/src/functions/repeatElement.js
@@ -37,6 +37,7 @@ export const FiniteRepeatElementSequence = Sequence.extend({
         return this;
     },
     bounded: () => true,
+    unbounded: () => false,
     done: function(){
         return this.finishedRepetitions >= this.repetitions;
     },
@@ -99,6 +100,7 @@ export const InfiniteRepeatElementSequence = Sequence.extend({
         return this;
     },
     bounded: () => false,
+    unbounded: () => true,
     done: () => false,
     length: null,
     left: null,

--- a/src/functions/reverse.js
+++ b/src/functions/reverse.js
@@ -17,6 +17,9 @@ export const ReverseSequence = Sequence.extend({
     bounded: function(){
         return this.source.bounded();
     },
+    unbounded: function(){
+        return this.source.unbounded();
+    },
     done: function(){
         return this.source.done();
     },

--- a/src/functions/sample.js
+++ b/src/functions/sample.js
@@ -21,6 +21,7 @@ export const DistinctRandomIndexSequence = Sequence.extend({
         ];
     },
     bounded: () => true,
+    unbounded: () => false,
     done: function(){
         return this.valueHistory.length > this.totalValues;
     },
@@ -102,6 +103,7 @@ const SampleSequence = Sequence.extend({
         );
     },
     bounded: () => true,
+    unbounded: () => false,
     done: function(){
         return this.indexes.valueHistory.length > this.samples;
     },

--- a/src/functions/shuffle.js
+++ b/src/functions/shuffle.js
@@ -81,6 +81,7 @@ export const ShuffleSequence = Sequence.extend({
         };
     },
     bounded: () => true,
+    unbounded: () => false,
     done: function(){
         return this.source.done();
     },

--- a/src/functions/stride.js
+++ b/src/functions/stride.js
@@ -31,6 +31,9 @@ export const PoppingStrideSequence = Sequence.extend({
     bounded: function(){
         return this.source.bounded();
     },
+    unbounded: function(){
+        return this.source.unbounded();
+    },
     done: function(){
         return this.source.done();
     },
@@ -87,6 +90,7 @@ export const IndexStrideSequence = Sequence.extend({
         this.maskAbsentMethods(source);
     },
     bounded: () => true,
+    unbounded: () => false,
     done: function(){
         return this.frontIndex >= this.backIndex;
     },

--- a/src/functions/tap.js
+++ b/src/functions/tap.js
@@ -14,6 +14,9 @@ export const TapSequence = Sequence.extend({
     bounded: function(){
         return this.source.bounded();
     },
+    unbounded: function(){
+        return this.source.unbounded();
+    },
     done: function(){
         return this.source.done();
     },


### PR DESCRIPTION
Resolves https://github.com/pineapplemachine/higher/issues/8

Some background: the `bounded` method is used to check if a sequence is known to end and `unbounded` to check if a sequence is known to not end. Both returning false means that higher can't know for sure either way; maybe it'll end and maybe it won't.

Some sequences were behaving badly because of the default `unbounded` implementation being inapplicable to them. This should fix all such issues and is a better pattern anyway.