### PR TITLE
Add rebase methods to sequences, use it to make collapse better

### DIFF
--- a/src/core/asSequence.js
+++ b/src/core/asSequence.js
@@ -129,6 +129,7 @@ export const ArraySequence = Sequence.extend({
         this.backIndex = this.highIndex;
         return this;
     },
+    rebase: null,
 });
 
 // Get a sequence for enumerating the characters in a string.
@@ -201,6 +202,7 @@ export const StringSequence = Sequence.extend({
         this.backIndex = this.highIndex;
         return this;
     },
+    rebase: null,
 });
 
 // Get a sequence that enumerates the key, value pairs of an arbitrary object.
@@ -251,6 +253,7 @@ export const ObjectSequence = Sequence.extend({
         this.keyIndex = 0;
         return this;
     },
+    rebase: null,
 });
 
 // Get a sequence that enumerates the items of an iterable.
@@ -283,6 +286,7 @@ export const IterableSequence = Sequence.extend({
     get: null,
     copy: null,
     reset: null,
+    rebase: null,
 });
 
 export default asSequence;

--- a/src/core/sequence.js
+++ b/src/core/sequence.js
@@ -119,12 +119,10 @@ Sequence.prototype.collapse = function(limit = -1){
             }
             i = breaking.collapseBreak(source, i);
             if(next){
-                // TODO: Can this be accomplished more safely?
-                // Idea: Reset method should accept an optional source,
-                // if it's passed then the sequence uses it as the new basis
-                next.source = arraySequence;
+                // TODO: Better thrown error
+                if(!next.rebase) throw "Sequence must support rebasing."
+                next.rebase(arraySequence);
                 arraySequence.backIndex = i;
-                if(next.sources) next.sources[0] = arraySequence;
             }
         }
         if(breaks[0] !== 0){

--- a/src/core/wrap.js
+++ b/src/core/wrap.js
@@ -6,6 +6,10 @@ import {Sequence} from "./sequence";
 import {isFunction, isIterable} from "./types";
 
 export const wrap = function(info){
+    // TODO: Better errors
+    if(!info.implementation) throw "No implementation!";
+    if(!info.arguments) throw "No argument information!";
+    if(!info.name && !info.names) throw "No names!";
     const fancy = wrap.fancy(info);
     fancy.names = info.names || [info.name];
     fancy.sequences = info.sequences;

--- a/src/functions/assumeBounded.js
+++ b/src/functions/assumeBounded.js
@@ -48,6 +48,10 @@ export const AssumeBoundedSequence = Sequence.extend({
         this.source.reset();
         return this;
     },
+    rebase: function(source){
+        this.source = source;
+        return this;
+    },
 });
 
 // An AssumeBoundedSequence can be used to assure higher that a potentially

--- a/src/functions/chunk.js
+++ b/src/functions/chunk.js
@@ -88,6 +88,10 @@ export const ForwardChunkSequence = Sequence.extend({
         this.source.reset();
         return this;
     },
+    rebase: function(source){
+        this.source = source;
+        return this;
+    },
 });
 
 // Implement chunking for sequences with slicing and known length.
@@ -162,6 +166,10 @@ export const BidirectionalChunkSequence = Sequence.extend({
     reset: function(){
         this.frontIndex = this.lowIndex;
         this.backIndex = this.highIndex;
+        return this;
+    },
+    rebase: function(source){
+        this.source = source;
         return this;
     },
 });

--- a/src/functions/concat.js
+++ b/src/functions/concat.js
@@ -113,6 +113,11 @@ export const ConcatSequence = Sequence.extend({
         this.backSourceIndex = this.sources.length;
         return this;
     },
+    rebase: function(source){
+        this.source = source;
+        this.sources[0] = source;
+        return this;
+    },
 });
 
 export const concat = wrap({

--- a/src/functions/count.js
+++ b/src/functions/count.js
@@ -65,8 +65,6 @@ Object.assign(SequenceCounter.prototype, {
         this.source.reset();
         return this;
     },
-});
-Object.assign(SequenceCounter.prototype, {
     sumAsync: function(){
         return new constants.Promise((resolve, reject) => {
             callAsync(() => resolve(this.sum()));

--- a/src/functions/distinct.js
+++ b/src/functions/distinct.js
@@ -50,6 +50,10 @@ export const DistinctSequence = Sequence.extend({
         this.history = {};
         return this;
     },
+    rebase: function(source){
+        this.source = source;
+        return this;
+    },
 });
 
 export const distinct = wrap({
@@ -62,7 +66,7 @@ export const distinct = wrap({
     arguments: {
         one: wrap.expecting.sequence
     },
-    imlementation: (source) => {
+    implementation: (source) => {
         return new DistinctSequence(source);
     },
 });

--- a/src/functions/dropHead.js
+++ b/src/functions/dropHead.js
@@ -56,7 +56,11 @@ export const DropHeadSequence = Sequence.extend({
     },
     reset: function(){
         this.source.reset();
-        this.DropHeadSequence = false;
+        this.initialized = false;
+        return this;
+    },
+    rebase: function(source){
+        this.source = source;
         return this;
     },
 });

--- a/src/functions/dropTail.js
+++ b/src/functions/dropTail.js
@@ -55,6 +55,10 @@ export const DropTailSequence = Sequence.extend({
         this.frontIndex = 0;
         return this;
     },
+    rebase: function(source){
+        this.source = source;
+        return this;
+    },
 });
 
 export const dropTail = wrap({

--- a/src/functions/empty.js
+++ b/src/functions/empty.js
@@ -31,6 +31,7 @@ export const EmptySequence = Sequence.extend({
     reset: function(){
         return this;
     },
+    rebase: null,
 });
 
 export const empty = wrap({

--- a/src/functions/enumerate.js
+++ b/src/functions/enumerate.js
@@ -69,6 +69,10 @@ export const EnumerateSequence = Sequence.extend({
         if(this.back) this.backIndex = start + (step * (source.length() - 1));
         return this;
     },
+    rebase: function(source){
+        this.source = source;
+        return this;
+    },
 });
 
 export const enumerate = wrap({

--- a/src/functions/filter.js
+++ b/src/functions/filter.js
@@ -84,6 +84,10 @@ export const FilterSequence = Sequence.extend({
         this.source.reset();
         return this;
     },
+    rebase: function(source){
+        this.source = source;
+        return this;
+    },
 });
 
 // Produce a new sequence enumerating only those elements of an input sequence

--- a/src/functions/findAll.js
+++ b/src/functions/findAll.js
@@ -286,6 +286,10 @@ export const ForwardFindSequence = Sequence.extend({
         delete this.popFront;
         return this;
     },
+    rebase: function(source){
+        this.source = source;
+        return this;
+    },
 });
 
 export const BackwardFindSequence = Sequence.extend({
@@ -423,6 +427,10 @@ export const BackwardFindSequence = Sequence.extend({
         delete this.done;
         delete this.front;
         delete this.popFront;
+        return this;
+    },
+    rebase: function(source){
+        this.source = source;
         return this;
     },
 });

--- a/src/functions/flatten.js
+++ b/src/functions/flatten.js
@@ -2,6 +2,7 @@ import {Sequence} from "../core/sequence";
 import {asSequence, validAsSequence} from "../core/asSequence";
 import {wrap} from "../core/wrap";
 
+// TODO: These sequences probably need to implement collapseBreak methods
 export const ForwardFlattenSequence = Sequence.extend({
     constructor: function ForwardFlattenSequence(source, frontSource = null){
         this.source = source;
@@ -49,6 +50,11 @@ export const ForwardFlattenSequence = Sequence.extend({
     slice: null,
     copy: null,
     reset: null,
+    rebase: function(source){
+        this.source = source;
+        this.frontSource = source;
+        return this;
+    },
 });
 
 export const BackwardFlattenSequence = Sequence.extend({
@@ -98,6 +104,11 @@ export const BackwardFlattenSequence = Sequence.extend({
     slice: null,
     copy: null,
     reset: null,
+    rebase: function(source){
+        this.source = source;
+        this.frontSource = source;
+        return this;
+    },
 });
 
 // Flatten a single level deep.
@@ -112,7 +123,7 @@ export const flatten = wrap({
     arguments: {
         one: wrap.expecting.sequence
     },
-    imlementation: (source) => {
+    implementation: (source) => {
         return new ForwardFlattenSequence(source);
     },
 });

--- a/src/functions/flattenDeep.js
+++ b/src/functions/flattenDeep.js
@@ -4,6 +4,7 @@ import {isArray, isIterable, isString} from "../core/types";
 import {wrap} from "../core/wrap";
 
 // TODO: Also write a backwards version of this sequence
+// TODO: This sequence probably needs a collapseBreak method
 export const FlattenDeepSequence = Sequence.extend({
     constructor: function FlattenDeepSequence(source){
         this.source = source;
@@ -80,6 +81,12 @@ export const FlattenDeepSequence = Sequence.extend({
     slice: null,
     copy: null,
     reset: null,
+    rebase: function(source){
+        this.source = source;
+        this.sourceStack = [source];
+        this.frontSource = source;
+        return this;
+    },
 });
 
 // Flatten recursively.

--- a/src/functions/from.js
+++ b/src/functions/from.js
@@ -92,6 +92,10 @@ export const FromSequence = Sequence.extend({
         delete this.popFront;
         return this;
     },
+    rebase: function(source){
+        this.source = source;
+        return this;
+    },
 });
 
 export const from = wrap({

--- a/src/functions/head.js
+++ b/src/functions/head.js
@@ -5,8 +5,8 @@ import {EmptySequence} from "./empty";
 
 // Fallback implementation of head function for when slicing is unavailable.
 export const HeadSequence = Sequence.extend({
-    constructor: function HeadSequence(elements, source, frontIndex = 0){
-        this.elements = elements;
+    constructor: function HeadSequence(headLength, source, frontIndex = 0){
+        this.headLength = headLength;
         this.source = source;
         this.frontIndex = frontIndex;
         this.maskAbsentMethods(source);
@@ -14,15 +14,15 @@ export const HeadSequence = Sequence.extend({
     bounded: () => true,
     unbounded: () => false,
     done: function(){
-        return this.frontIndex >= this.elements || this.source.done();
+        return this.frontIndex >= this.headLength || this.source.done();
     },
     length: function(){
         const sourceLength = this.source.length();
-        return sourceLength < this.elements ? sourceLength : this.elements;
+        return sourceLength < this.headLength ? sourceLength : this.headLength;
     },
     left: function(){
         const sourceLeft = this.source.left();
-        const indexLeft = this.elements - this.frontIndex;
+        const indexLeft = this.headLength - this.frontIndex;
         return sourceLeft < indexLeft ? sourceLeft : indexLeft;
     },
     front: function(){
@@ -42,12 +42,16 @@ export const HeadSequence = Sequence.extend({
     },
     copy: function(){
         return new HeadSequence(
-            this.elements, this.source.copy(), this.frontIndex
+            this.headLength, this.source.copy(), this.frontIndex
         );
     },
     reset: function(){
         this.source.reset();
         this.frontIndex = 0;
+        return this;
+    },
+    rebase: function(source){
+        this.source = source;
         return this;
     },
 });

--- a/src/functions/join.js
+++ b/src/functions/join.js
@@ -89,6 +89,14 @@ export const ForwardJoinSequence = Sequence.extend({
     slice: null,
     copy: null,
     reset: null,
+    rebase: function(source){
+        this.source = source;
+        // Must uninitialize to rebase
+        delete this.done;
+        delete this.front;
+        delete this.popFront;
+        return this;
+    },
 });
 
 export const BackwardJoinSequence = Sequence.extend({
@@ -179,6 +187,14 @@ export const BackwardJoinSequence = Sequence.extend({
     slice: null,
     copy: null,
     reset: null,
+    rebase: function(source){
+        this.source = source;
+        // Must uninitialize to rebase
+        delete this.done;
+        delete this.front;
+        delete this.popFront;
+        return this;
+    },
 });
 
 export const join = wrap({

--- a/src/functions/map.js
+++ b/src/functions/map.js
@@ -56,6 +56,10 @@ export const SingularMapSequence = Sequence.extend({
         this.source.reset();
         return this;
     },
+    rebase: function(source){
+        this.source = source;
+        return this;
+    },
 });
 
 // Map sequence for any number of input sequences.
@@ -148,6 +152,11 @@ export const PluralMapSequence = Sequence.extend({
     },
     reset: function(){
         for(const source of this.sources) source.reset();
+        return this;
+    },
+    rebase: function(source){
+        this.source = source;
+        this.sources[0] = source;
         return this;
     },
 });

--- a/src/functions/ngrams.js
+++ b/src/functions/ngrams.js
@@ -8,6 +8,7 @@ export const NgramSequence = Sequence.extend({
         this.ngramSize = Math.floor(+ngramSize);
         this.source = source;
         this.currentNgram = currentNgram || [];
+        // TODO: Move this into initializiation logic
         while(!source.done() && this.currentNgram.length < this.ngramSize){
             this.currentNgram.push(source.nextFront());
         }
@@ -62,6 +63,16 @@ export const NgramSequence = Sequence.extend({
     reset: function(){
         this.source.reset();
         this.currentNgram = [];
+        // TODO: Move this into initializiation logic
+        while(!this.source.done() && this.currentNgram.length < this.ngramSize){
+            this.currentNgram.push(this.source.nextFront());
+        }
+        return this;
+    },
+    rebase: function(source){
+        this.source = source;
+        this.currentNgram = [];
+        // TODO: Move this into initializiation logic
         while(!this.source.done() && this.currentNgram.length < this.ngramSize){
             this.currentNgram.push(this.source.nextFront());
         }

--- a/src/functions/one.js
+++ b/src/functions/one.js
@@ -60,6 +60,7 @@ export const OneElementSequence = Sequence.extend({
         this.isDone = false;
         return this;
     },
+    rebase: null,
 });
 
 export const one = wrap({

--- a/src/functions/pad.js
+++ b/src/functions/pad.js
@@ -82,6 +82,10 @@ export const PadLeftSequence = Sequence.extend({
         this.padCount = 0;
         return this;
     },
+    rebase: function(source){
+        this.source = source;
+        return this;
+    },
 });
 
 export const PadRightSequence = Sequence.extend({
@@ -166,6 +170,10 @@ export const PadRightSequence = Sequence.extend({
     reset: function(){
         this.source.reset();
         this.padCount = 0;
+        return this;
+    },
+    rebase: function(source){
+        this.source = source;
         return this;
     },
 });

--- a/src/functions/range.js
+++ b/src/functions/range.js
@@ -58,6 +58,7 @@ export const NumberRangeSequence = Sequence.extend({
         this.backValue = this.end;
         return this;
     },
+    rebase: null,
 });
 
 // Result of calling range with a step of greater than 0.
@@ -121,6 +122,7 @@ export const ForwardNumberRangeSequence = Sequence.extend({
         this.backValue = this.end;
         return this;
     },
+    rebase: null,
 });
 
 // Result of calling range with a step of less than 0.
@@ -184,6 +186,7 @@ export const BackwardNumberRangeSequence = Sequence.extend({
         this.backValue = this.end;
         return this;
     },
+    rebase: null,
 });
 
 // Create a sequence enumerating numbers in a linear range.

--- a/src/functions/recur.js
+++ b/src/functions/recur.js
@@ -40,6 +40,7 @@ export const RecurSequence = Sequence.extend({
         this.frontValue = this.seedValue;
         return this;
     },
+    rebase: null,
 });
 
 // Produce a sequence via repeated application of a transformation function

--- a/src/functions/reduce.js
+++ b/src/functions/reduce.js
@@ -108,6 +108,14 @@ export const ReduceSequence = Sequence.extend({
         }
         return this;
     },
+    rebase: function(source){
+        this.source = source;
+        // TODO: Move into initialization logic
+        if(!this.hasSeed && !source.done()){
+            this.accumulator = source.nextFront();
+        }
+        return this;
+    },
 });
 
 export const reduce = wrap({

--- a/src/functions/repeat.js
+++ b/src/functions/repeat.js
@@ -140,6 +140,12 @@ export const FiniteRepeatSequence = Sequence.extend({
         }
         return this;
     },
+    rebase: function(source){
+        this.source = source;
+        this.frontSource = null;
+        this.backSource = null;
+        return this;
+    },
     collapseBreak: function(target, length){
         if(this.repetitions === 0){
             return 0;
@@ -226,8 +232,14 @@ export const InfiniteRepeatSequence = Sequence.extend({
         this.frontSource = null;
         this.backSource = null;
     },
+    rebase: function(source){
+        this.source = source;
+        this.frontSource = null;
+        this.backSource = null;
+        return this;
+    },
     collapseBreak: function(target, length){
-        // TODO: Can this be fixed?
+        // TODO: Can this possibly be fixed?
         throw "Cannot collapse infinitely repeated sequence.";
     },
 });

--- a/src/functions/repeatElement.js
+++ b/src/functions/repeatElement.js
@@ -76,6 +76,7 @@ export const FiniteRepeatElementSequence = Sequence.extend({
         this.finishedRepetitions = 0;
         return this;
     },
+    rebase: null,
 });
 
 export const InfiniteRepeatElementSequence = Sequence.extend({
@@ -126,6 +127,7 @@ export const InfiniteRepeatElementSequence = Sequence.extend({
     reset: function(){
         return this;
     },
+    rebase: null,
 });
 
 // Produce a sequence that repeats a single element.

--- a/src/functions/reverse.js
+++ b/src/functions/reverse.js
@@ -63,6 +63,10 @@ export const ReverseSequence = Sequence.extend({
         this.source.reset();
         return this;
     },
+    rebase: function(source){
+        this.source = source;
+        return this;
+    },
     // This sequence requires special handling when collapsing.
     collapseBreak: function(target, length){
         let i = 0;

--- a/src/functions/sample.js
+++ b/src/functions/sample.js
@@ -90,9 +90,11 @@ export const DistinctRandomIndexSequence = Sequence.extend({
     // TODO: Use resettable RNG objects instead of e.g. Math.random?
     copy: null,
     reset: null,
+    rebase: null,
 });
 
 // Input sequence must have length and indexing.
+// TODO: This sequence probably needs a collapseBreak method.
 const SampleSequence = Sequence.extend({
     constructor: function(samples, random, source, indexes = undefined){
         this.samples = samples;
@@ -129,6 +131,10 @@ const SampleSequence = Sequence.extend({
     // TODO: Use resettable RNG objects instead of e.g. Math.random?
     copy: null,
     reset: null,
+    rebase: function(source){
+        this.source = source;
+        return this;
+    },
 });
 
 export const sample = wrap({

--- a/src/functions/shuffle.js
+++ b/src/functions/shuffle.js
@@ -128,6 +128,10 @@ export const ShuffleSequence = Sequence.extend({
     reset: function(){
         return this;
     },
+    rebase: function(source){
+        this.source = source;
+        return this;
+    },
     collapseBreak: function(target, length){
         for(let i = 0; i < length; i++){
             const j = Math.floor(this.random() * i);

--- a/src/functions/split.js
+++ b/src/functions/split.js
@@ -91,6 +91,13 @@ export const ForwardSplitSequence = Sequence.extend({
         this.findDelimiters.reset();
         return this;
     },
+    rebase: function(source){
+        this.source = source;
+        this.findDelimiters = new ForwardFindSequence(
+            this.compare, source, this.delimiter.copy()
+        );
+        return this;
+    },
 });
 
 export const BackwardSplitSequence = Sequence.extend({
@@ -178,6 +185,13 @@ export const BackwardSplitSequence = Sequence.extend({
     },
     reset: function(){
         this.findDelimiters.reset();
+        return this;
+    },
+    rebase: function(source){
+        this.source = source;
+        this.findDelimiters = new BackwardFindSequence(
+            this.compare, source, this.delimiter.copy()
+        );
         return this;
     },
 });

--- a/src/functions/stride.js
+++ b/src/functions/stride.js
@@ -72,6 +72,10 @@ export const PoppingStrideSequence = Sequence.extend({
         this.source.reset();
         return this;
     },
+    rebase: function(source){
+        this.source = source;
+        return this;
+    },
 });
 
 // Implement stride using indexing.
@@ -132,6 +136,10 @@ export const IndexStrideSequence = Sequence.extend({
         this.frontIndex = 0;
         this.backIndex = source.length();
         this.backIndex -= (this.backIndex % strideLength);
+        return this;
+    },
+    rebase: function(source){
+        this.source = source;
         return this;
     },
 });

--- a/src/functions/tap.js
+++ b/src/functions/tap.js
@@ -69,6 +69,10 @@ export const TapSequence = Sequence.extend({
         this.source.reset();
         return this;
     },
+    rebase: function(source){
+        this.source = source;
+        return this;
+    },
 });
 
 // Like each, except the callbacks are invoked as the sequence is consumed,

--- a/src/functions/tee.js
+++ b/src/functions/tee.js
@@ -74,6 +74,31 @@ export const TeeSequence = Sequence.extend({
         return sequence;
     },
     reset: null,
+    // Implementation is weird because rebasing this sequence must not affect
+    // the state of its companion TeeSequences.
+    rebase: function(source){
+        // Remove from buffer
+        const otherSequences = [];
+        for(const sequence of this.elementBuffer.sequences){
+            if(sequence !== this) otherSequences.push(sequence);
+        }
+        this.elementBuffer.sequences = otherSequences;
+        // Change methods
+        this.source = source;
+        this.done = function(){
+            return this.source.done();
+        };
+        this.front = function(){
+            return this.source.front();
+        };
+        this.popFront = function(){
+            return this.source.popFront();
+        };
+        this.rebase = function(source){
+            this.source = source;
+        };
+        return this;
+    },
 });
 
 // Produce several sequences enumerating the elements of a single source

--- a/src/functions/until.js
+++ b/src/functions/until.js
@@ -14,6 +14,7 @@ export const UntilSequence = Sequence.extend({
             this.frontValue = frontValue;
             this.satisfied = satisfied;
         }else{
+            // TODO: This should be in an initialization method
             this.frontValue = source.nextFront();
             this.satisfied = predicate(this.frontValue);
         }
@@ -69,6 +70,15 @@ export const UntilSequence = Sequence.extend({
         this.source.reset();
         this.included = !this.isInclusive;
         if(!this.source.done()){
+            this.frontValue = this.source.nextFront();
+            this.satisfied = this.predicate(this.frontValue);
+        }
+        return this;
+    },
+    rebase: function(source){
+        this.source = source;
+        if(!this.source.done()){
+            // TODO: This should be in an initialization method
             this.frontValue = this.source.nextFront();
             this.satisfied = this.predicate(this.frontValue);
         }


### PR DESCRIPTION
This is a less failure prone solution than arbitrarily reassigning the "source" attribute as was being done before

Collapsing still needs some love but this is still a step in the right direction

Resolves https://github.com/pineapplemachine/higher/issues/21

FYI @jpsullivan: another (fairly minor) sweeping change