### PR TITLE
Possible pattern for function tests and documentation

### DIFF
--- a/src/functions/negate.js
+++ b/src/functions/negate.js
@@ -3,13 +3,39 @@ import {wrap} from "../core/wrap";
 // Get the complement of a function.
 export const negate = wrap({
     name: "negate",
+    summary: "Get the logical negation of a predicate function.",
+    docs: process.env.NODE_ENV !== "development" ? undefined : {
+        expects: (`
+            The function expects a single predicate function as its input.
+        `),
+        returns: (`
+            The function builds and returns a function returning true for
+            which inputs producing a falsey value when passed to the
+            inputted predicate and returning false for all inputs producing
+            a truthy value when passed to that predicate.
+        `),
+        examples: [
+            "basicUsage"
+        ],
+        related: [
+            "allPass", "anyPass", "nonePass"
+        ],
+    },
     attachSequence: false,
     async: false,
     arguments: {
         one: wrap.expecting.function
     },
     implementation: (predicate) => {
-        return (...args) => (!prediate(...args));
+        return (...args) => (!predicate(...args));
+    },
+    tests: process.env.NODE_ENV !== "development" ? undefined : {
+        "basicUsage": hi => {
+            const even = (a) => (a % 2 === 0);
+            const odd = hi.negate(even);
+            hi.assert(even(2));
+            hi.assert(odd(3));
+        },
     },
 });
 

--- a/src/higher.js
+++ b/src/higher.js
@@ -11,10 +11,13 @@ Object.assign(hi, {
     error: {},
     // Sequence types will be placed here.
     sequence: {},
+    // Registered functions will be placed here.
+    functions: [],
     
     // Receives an object or objects returned by the wrap function.
     register: function(...fancyFunctions){
         for(const fancy of fancyFunctions){
+            this.functions.push(fancy);
             for(const name of fancy.names){
                 this[name] = fancy;
                 if(fancy.async){
@@ -29,6 +32,15 @@ Object.assign(hi, {
             }
         }
         return fancyFunctions[0];
+    },
+    
+    // Run all tests
+    test: process.env.NODE_ENV !== "development" ? undefined : function(){
+        const result = {};
+        for(const func of this.functions){
+            if(func.test) result[func.name] = func.test(this);
+        }
+        return result;
     },
 });
 


### PR DESCRIPTION
When building, the minified output does not have the docs or tests attributes as shown in `negate.js` here, which is awesome.

What would be much nicer is if it wasn't necessary to include `process.env.NODE_ENV !== "development" ? undefined : ...` all over the place and to refer to some constant e.g. `isProd` instead, but so far I haven't gotten that to work.

I am hoping also to have similar conditional documentation objects assigned to sequence types. And I've been tumbling around an idea for contracts that would be like generic tests for consistent sequence behavior e.g. bidirectional sequences showing the same elements forward and back, indexed sequences having the result of `sequence.index(i)` be consistent with traversal, `length` and `left` reporting correct element counts, etc, though I haven't done anything with that in this PR.