### PR TITLE
Better equality checking tools in unit tests

### DIFF
--- a/src/core/arrayAsSequence.js
+++ b/src/core/arrayAsSequence.js
@@ -115,6 +115,7 @@ export const arrayAsSequence = wrap({
     async: false,
     asSequence: {
         // First priority core converter
+        implicit: true,
         priority: -1000,
         predicate: isArray,
         bounded: () => true,

--- a/src/core/asSequence.js
+++ b/src/core/asSequence.js
@@ -2,12 +2,20 @@ import {constants} from "./constants";
 import {isIterable, isObject} from "./types";
 import {isSequence} from "./sequence";
 
-// True when asSequence(value) would return a sequence.
+// True when asSequence(value) could return a sequence.
 export const validAsSequence = (value) => {
     // Easy short-circuit for core sequence converters
     if(isIterable(value) || isObject(value)) return true;
     for(const converter of asSequence.converters){
         if(converter.predicate(value)) return true;
+    }
+    return false;
+};
+
+export const validAsImplicitSequence = (value) => {
+    if(isSequence(value)) return true;
+    for(const converter of asSequence.converters){
+        if(converter.predicate(value)) return converter.implicit;
     }
     return false;
 };

--- a/src/core/assert.js
+++ b/src/core/assert.js
@@ -1,5 +1,6 @@
 import {asSequence} from "./asSequence";
 import {error} from "./error";
+import {isEqual} from "./isEqual";
 import {isSequence} from "./sequence";
 import {isArray, isFunction, isUndefined} from "./types";
 
@@ -43,30 +44,19 @@ export const assertUndefined = function(value, message = undefined){
 
 // Throw an error if all the given values aren't equal.
 export const assertEqual = function(...values){
-    for(let i = 1; i < values.length; i++){
-        if(values[i] !== values[0]) throw AssertError(
-            "Values must be equal.", values
-        );
-    }
-    return values[0];
+    if(values.length === 0) return undefined;
+    if(!isEqual(...values)) throw AssertError(
+        "Values must be equal.", values
+    );
+    return values;
 };
 
-// Throw an error if the elements of two sequences aren't equal.
-// Compares elements recursively, i.e. if the inputs are sequences of sequences
-// then those corresponding contained sequences are checked for equality, too.
-export const assertSeqEqual = function(sequenceA, sequenceB){
-    const compare = (a, b) => {
-        if(isSequence(a) || isSequence(b) || isArray(a) || isArray(b)){
-            return equals.implementation(compare, [
-                asSequence(a), asSequence(b)
-            ]);
-        }else{
-            return a === b;
-        }
-    };
-    if(!compare(sequenceA, sequenceB)) throw AssertError(
-        "Sequences must be equal.", [sequenceA, sequenceB]
+export const assertNotEqual = function(...values){
+    if(values.length === 0) return undefined;
+    if(isEqual(...values)) throw AssertError(
+        "Values must not be equal.", values
     );
+    return values;
 };
 
 export const assertEmpty = function(source, message = undefined){

--- a/src/core/isEqual.js
+++ b/src/core/isEqual.js
@@ -1,0 +1,70 @@
+import {asSequence, validAsImplicitSequence} from "./asSequence";
+import {isObject} from "./types";
+
+// Compare sequences for deep isEquality.
+export const sequencesEqual = (...sources) => {
+    if(sources.length > 1){
+        const sequences = [];
+        for(const source of sources){
+            sequences.push(asSequence(source));
+        }
+        while(!sequences[0].done()){
+            const element = sequences[0].nextFront();
+            for(let i = 1; i < sequences.length; i++){
+                if(sequences[i].done()) return false;
+                if(!isEqual(element, sequences[i].nextFront())) return false;
+            }
+        }
+    }
+    return true;
+};
+
+// Compare arbitrary objects for deep isEquality.
+export const objectsEqual = (...objects) => {
+    if(objects.length > 1){
+        const visited = {};
+        for(let i = 0; i < objects.length; i++){
+            for(const key in objects[i]){
+                if(!visited[key]){
+                    visited.key = true;
+                    const compare = [];
+                    for(let j = 0; i < objects.length; j++){
+                        compare.push(objects[j][key]);
+                    }
+                    if(!isEqual(...compare)) return false;
+                }
+            }
+        }
+    }
+    return true;
+};
+
+// Compare values for isEquality.
+export const valuesEqual = (...values) => {
+    for(let i = 1; i < values.length; i++){
+        if(values[i] !== values[0]) return false;
+    }
+    return true;
+};
+
+// Compare values for isEquality.
+// If they are all implicitly valid as sequences, treat them as sequences.
+// If they are all objects, treat them as objects.
+export const isEqual = (...values) => {
+    if(values.length <= 1) return true;
+    let noObject = false;
+    let noSequence = false;
+    for(const value of values){
+        if(!isObject(value)) noObject = true;
+        if(!validAsImplicitSequence(value)) noSequence = true;
+    }
+    if(!noSequence){
+        return sequencesEqual(...values);
+    }else if(!noObject){
+        return objectsEqual(...values);
+    }else{
+        return valuesEqual(...values);
+    }
+};
+
+export default isEqual;

--- a/src/core/iterableAsSequence.js
+++ b/src/core/iterableAsSequence.js
@@ -69,6 +69,7 @@ export const iterableAsSequence = wrap({
     asSequence: {
         // Extremely low priority converter due to how generic it is.
         // Second-last priority of all core converters, before objectAsSequence.
+        implicit: true,
         priority: 800,
         predicate: isIterable,
         bounded: () => false,

--- a/src/core/objectAsSequence.js
+++ b/src/core/objectAsSequence.js
@@ -156,6 +156,7 @@ export const objectAsSequence = wrap({
     asSequence: {
         // Extremely low priority converter due to how generic it is.
         // Last priority of all core converters.
+        implicit: false,
         priority: 1000,
         predicate: isObject,
         bounded: () => true,

--- a/src/core/stringAsSequence.js
+++ b/src/core/stringAsSequence.js
@@ -92,6 +92,7 @@ export const stringAsSequence = wrap({
     async: false,
     asSequence: {
         // Comes after only array conversion and before generic iterable conversion.
+        implicit: false,
         priority: -800,
         predicate: isString,
         bounded: () => true,

--- a/src/functions/collapse.js
+++ b/src/functions/collapse.js
@@ -183,7 +183,7 @@ export const collapse = wrap({
         "basicUsage": hi => {
             const array = [1, 2, 3, 4, 5];
             hi.map(array, n => n * n).collapse();
-            hi.assertSeqEqual(array, [1, 4, 9, 16, 25]);
+            hi.assertEqual(array, [1, 4, 9, 16, 25]);
         },
     },
 });

--- a/src/functions/tail.js
+++ b/src/functions/tail.js
@@ -86,7 +86,7 @@ export const tail = wrap({
     },
     tests: process.env.NODE_ENV !== "development" ? undefined : {
         "basicUsage": hi => {
-            hi.assertSeqEqual(hi.tail(3, [0, 1, 2, 3, 4, 5]), [3, 4, 5]);
+            hi.assertEqual(hi.tail(3, [0, 1, 2, 3, 4, 5]), [3, 4, 5]);
         },
         "zeroLength": hi => {
             hi.assertEmpty(hi.tail(0, []));
@@ -102,30 +102,30 @@ export const tail = wrap({
         },
         "boundedSlicingInput": hi => {
             const array = [0, 1, 2, 3, 4, 5, 6, 7];
-            hi.assertSeqEqual(hi.tail(1, array), [7]);
-            hi.assertSeqEqual(hi.tail(2, array), [6, 7]);
-            hi.assertSeqEqual(hi.tail(4, array), [4, 5, 6, 7]);
-            hi.assertSeqEqual(hi.tail(8, array), [0, 1, 2, 3, 4, 5, 6, 7]);
-            hi.assertSeqEqual(hi.tail(20, array), [0, 1, 2, 3, 4, 5, 6, 7]);
+            hi.assertEqual(hi.tail(1, array), [7]);
+            hi.assertEqual(hi.tail(2, array), [6, 7]);
+            hi.assertEqual(hi.tail(4, array), [4, 5, 6, 7]);
+            hi.assertEqual(hi.tail(8, array), [0, 1, 2, 3, 4, 5, 6, 7]);
+            hi.assertEqual(hi.tail(20, array), [0, 1, 2, 3, 4, 5, 6, 7]);
         },
         "unboundedBidirectionalInput": hi => {
             const seq = () => hi.repeat([0, 1, 2, 3]);
             hi.assertEmpty(seq().tail(0));
-            hi.assertSeqEqual(seq().tail(1), [3]);
-            hi.assertSeqEqual(seq().tail(2), [2, 3]);
-            hi.assertSeqEqual(seq().tail(4), [0, 1, 2, 3]);
-            hi.assertSeqEqual(seq().tail(6), [2, 3, 0, 1, 2, 3]);
+            hi.assertEqual(seq().tail(1), [3]);
+            hi.assertEqual(seq().tail(2), [2, 3]);
+            hi.assertEqual(seq().tail(4), [0, 1, 2, 3]);
+            hi.assertEqual(seq().tail(6), [2, 3, 0, 1, 2, 3]);
         },
         "boundedNonSlicingInput": hi => {
             const seq = () => (
                 hi.recur(i => i + 1).seed(0).until(i => i >= 8).assumeBounded()
             );
             hi.assertEmpty(seq().tail(0));
-            hi.assertSeqEqual(seq().tail(1), [7]);
-            hi.assertSeqEqual(seq().tail(2), [6, 7]);
-            hi.assertSeqEqual(seq().tail(4), [4, 5, 6, 7]);
-            hi.assertSeqEqual(seq().tail(8), [0, 1, 2, 3, 4, 5, 6, 7]);
-            hi.assertSeqEqual(seq().tail(20), [0, 1, 2, 3, 4, 5, 6, 7]);
+            hi.assertEqual(seq().tail(1), [7]);
+            hi.assertEqual(seq().tail(2), [6, 7]);
+            hi.assertEqual(seq().tail(4), [4, 5, 6, 7]);
+            hi.assertEqual(seq().tail(8), [0, 1, 2, 3, 4, 5, 6, 7]);
+            hi.assertEqual(seq().tail(20), [0, 1, 2, 3, 4, 5, 6, 7]);
         },
         "illegalInput": hi => {
             hi.assertFail(

--- a/src/higher.js
+++ b/src/higher.js
@@ -30,9 +30,16 @@ Object.assign(hi, {
     
     // Run all tests
     test: process.env.NODE_ENV !== "development" ? undefined : function(){
-        const result = {};
+        const result = {
+            functions: {},
+            failures: [],
+        };
         for(const func of this.functions){
-            if(func.test) result[func.name] = func.test(this);
+            if(func.test){
+                const status = func.test(this);
+                result.functions[func.name] = status;
+                for(const failure of status.fail) result.failures.push(failure);
+            }
         }
         return result;
     },
@@ -43,23 +50,25 @@ import {args} from "./core/arguments";
 hi.args = args;
 
 import {
-    asSequence, validAsSequence, validAsBoundedSequence, validAsUnboundedSequence
+    asSequence, validAsSequence, validAsImplicitSequence,
+    validAsBoundedSequence, validAsUnboundedSequence
 } from "./core/asSequence";
 hi.asSequence = asSequence;
 hi.validAsSequence = validAsSequence;
+hi.validAsImplicitSequence = validAsImplicitSequence;
 hi.validAsBoundedSequence = validAsBoundedSequence;
 hi.validAsUnboundedSequence = validAsUnboundedSequence;
 
 import {
     AssertError, assert, assertNot, assertUndefined,
-    assertEqual, assertSeqEqual, assertEmpty, assertFail
+    assertEqual, assertNotEqual, assertEmpty, assertFail
 } from "./core/assert";
 hi.error.AssertError = AssertError;
 hi.assert = assert;
 hi.assertNot = assertNot;
 hi.assertUndefined = assertUndefined;
 hi.assertEqual = assertEqual;
-hi.assertSeqEqual = assertSeqEqual;
+hi.assertNotEqual = assertNotEqual;
 hi.assertEmpty = assertEmpty;
 hi.assertFail = assertFail;
 

--- a/src/test/testRunner.js
+++ b/src/test/testRunner.js
@@ -5,19 +5,19 @@ console.log(`Running tests for higher@${hi.version}.`);
 const results = hi.test();
 
 const functionNames = [];
-for(const functionName in results) functionNames.push(functionName);
+for(const functionName in results.functions) functionNames.push(functionName);
 functionNames.sort();
 
 for(const name of functionNames){
-    const passed = results[name].pass.length;
-    const failed = results[name].fail.length;
+    const passed = results.functions[name].pass.length;
+    const failed = results.functions[name].fail.length;
     const total = passed + failed;
     console.log(`${name}: passed ${passed} of ${total}`);
 }
 
 let failures = 0;
 for(const name of functionNames){
-    for(const failure of results[name].fail){
+    for(const failure of results.functions[name].fail){
         console.error(`${name}.${failure.name} failed: ${failure.error.stack}`);
         failures++;
     }


### PR DESCRIPTION
Added `isEqual` function, rewrote `assertEqual`, got rid of `assertSeqEqual`