### PR TITLE
Fixed npm test on Windows

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1576,6 +1576,12 @@
             "integrity": "sha1-q0SEl8JlZuHilBPogyB9V8/nvtQ=",
             "dev": true
         },
+        "cross-env": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-5.0.1.tgz",
+            "integrity": "sha1-/05y6kO0faJIa0On8gQ7JgnkSRM=",
+            "dev": true
+        },
         "cross-spawn": {
             "version": "5.1.0",
             "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
@@ -3335,6 +3341,12 @@
             "version": "0.2.1",
             "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
             "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
+            "dev": true
+        },
+        "is-windows": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.1.tgz",
+            "integrity": "sha1-MQ23D3QtJZoWo2kgK1GvhCMzENk=",
             "dev": true
         },
         "isarray": {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "dependencies": {},
     "devDependencies": {
         "babel-eslint": "7.2.2",
+        "cross-env": "^5.0.1",
         "eslint": "4.1.0",
         "eslint-config-google": "0.8.0",
         "nwb": "0.17.x",
@@ -34,7 +35,7 @@
         "build": "nwb build-web-module",
         "clean": "nwb clean-module && nwb clean-demo",
         "start": "nwb serve-react-demo",
-        "test": "export NODE_ENV='development' && nwb build && node lib/test/testRunner.js",
+        "test": "cross-env NODE_ENV=development nwb build && cross-env NODE_ENV=development node lib/test/testRunner.js",
         "test:coverage": "nwb test --coverage",
         "test:watch": "nwb test --server"
     }

--- a/src/higher.js
+++ b/src/higher.js
@@ -1,19 +1,19 @@
 export const hi = (source) => {
     return hi.asSequence(source);
-}
+};
 
 export default hi;
 
 Object.assign(hi, {
     version: "0.1.0",
-    
+
     // Error types will be placed here.
     error: {},
     // Sequence types will be placed here.
     sequence: {},
     // Registered functions will be placed here.
     functions: [],
-    
+
     // Receives an object or objects returned by the wrap function.
     register: function(...fancyFunctions){
         for(const fancy of fancyFunctions){
@@ -27,7 +27,7 @@ Object.assign(hi, {
         }
         return fancyFunctions[0];
     },
-    
+
     // Run all tests
     test: process.env.NODE_ENV !== "development" ? undefined : function(){
         const result = {
@@ -51,7 +51,7 @@ hi.args = args;
 
 import {
     asSequence, validAsSequence, validAsImplicitSequence,
-    validAsBoundedSequence, validAsUnboundedSequence
+    validAsBoundedSequence, validAsUnboundedSequence,
 } from "./core/asSequence";
 hi.asSequence = asSequence;
 hi.validAsSequence = validAsSequence;
@@ -61,7 +61,7 @@ hi.validAsUnboundedSequence = validAsUnboundedSequence;
 
 import {
     AssertError, assert, assertNot, assertUndefined,
-    assertEqual, assertNotEqual, assertEmpty, assertFail
+    assertEqual, assertNotEqual, assertEmpty, assertFail,
 } from "./core/assert";
 hi.error.AssertError = AssertError;
 hi.assert = assert;
@@ -88,7 +88,7 @@ hi.sequence = Sequence.types; // This attribute will contain all sequence types
 
 import {
     isUndefined, isBoolean, isNumber, isInteger, isString, isArray,
-    isObject, isFunction, isIterable
+    isObject, isFunction, isIterable,
 } from "./core/types";
 hi.isUndefined = isUndefined;
 hi.isBoolean = isBoolean;


### PR DESCRIPTION
The `export` command causes Windows to freak out, and the recommended solution is to replace it with `set`. The route I went was to use the cross-platform enabled library [cross-env](https://github.com/kentcdodds/cross-env) which works in all environments.

The `test` npm script command has been augmented to utilize this.