### PR TITLE
Add tests to ngrams, bigrams, and trigrams functions

### DIFF
--- a/src/functions/bigrams.js
+++ b/src/functions/bigrams.js
@@ -21,6 +21,21 @@ export const bigrams = wrap({
             return new TrackingNgramSequence(2, source);
         }
     },
+    tests: process.env.NODE_ENV !== "development" ? undefined : {
+        "basicUsage": hi => {
+            const words = ["hello", "world", "how", "do?"];
+            hi.assertEqual(hi.bigrams(words), [
+                ["hello", "world"], ["world", "how"], ["how", "do?"]
+            ]);
+        },
+        "emptyInput": hi => {
+            hi.assertEmpty(hi.emptySequence().bigrams());
+        },
+        "unboundedInput": hi => {
+            const seq = hi.counter().bigrams();
+            hi.assert(seq.startsWith(hi.isEqual, [[0, 1], [1, 2], [2, 3], [3, 4]]));
+        },
+    },
 });
 
 export default bigrams;

--- a/src/functions/ngrams.js
+++ b/src/functions/ngrams.js
@@ -5,22 +5,52 @@ import {ArraySequence} from "./arrayAsSequence";
 import {InfiniteRepeatElementSequence} from "./repeatElement";
 
 export const SlicingNgramSequence = Sequence.extend({
+    summary: "Enumerate ngrams in a sequence.",
+    supportRequired: [
+        "length", "slice",
+    ],
+    supportsAlways: [
+        "back", "index", "copy", "reset",
+    ],
+    docs: process.env.NODE_ENV !== "development" ? undefined : {
+        introduced: "higher@1.0.0",
+        expects: (`
+            The constructor expects a number indicating ngram size and one
+            sequence as input. Ngram size must be a positive integer.
+        `),
+    },
+    getSequence: process.env.NODE_ENV !== "development" ? undefined : [
+        hi => new SlicingNgramSequence(1, hi.emptySequence()),
+        hi => new SlicingNgramSequence(2, hi.emptySequence()),
+        hi => new SlicingNgramSequence(3, hi.emptySequence()),
+        hi => new SlicingNgramSequence(1, hi.range(1)),
+        hi => new SlicingNgramSequence(3, hi.range(1)),
+        hi => new SlicingNgramSequence(1, hi.range(2)),
+        hi => new SlicingNgramSequence(2, hi.range(2)),
+        hi => new SlicingNgramSequence(3, hi.range(2)),
+        hi => new SlicingNgramSequence(1, hi.range(3)),
+        hi => new SlicingNgramSequence(2, hi.range(3)),
+        hi => new SlicingNgramSequence(3, hi.range(3)),
+        hi => new SlicingNgramSequence(4, hi.range(3)),
+        hi => new SlicingNgramSequence(3, hi("some string")),
+    ],
     constructor: function SlicingNgramSequence(
         ngramSize, source,
         lowIndex = undefined, highIndex = undefined,
         frontIndex = undefined, backIndex = undefined
     ){
-        if(!source.length) throw "Source must have length.";
-        if(!source.slice) throw "Source must allow slicing.";
+        // TODO: Better arguments validation
+        if(!source.length) throw new Error("Source must have length.");
+        if(!source.slice) throw new Error("Source must allow slicing.");
+        if(ngramSize < 1) throw new Error("Ngram size must be at least 1.");
         this.ngramSize = ngramSize;
         this.source = source;
         this.lowIndex = lowIndex || 0;
         this.highIndex = (highIndex !== undefined ?
-            highIndex : 1 + source.length() - ngramSize
+            highIndex : Math.max(this.lowIndex, 1 + source.length() - ngramSize)
         );
         this.frontIndex = frontIndex !== undefined ? frontIndex : this.lowIndex;
         this.backIndex = backIndex !== undefined ? backIndex : this.highIndex;
-        this.maskAbsentMethods(source);
     },
     bounded: () => true,
     unbounded: () => false,
@@ -77,9 +107,37 @@ export const SlicingNgramSequence = Sequence.extend({
 });
 
 export const TrackingNgramSequence = Sequence.extend({
+    summary: "Enumerate ngrams in a sequence.",
+    supportsWith: [
+        "index", "slice", "copy", "reset",
+    ],
+    docs: process.env.NODE_ENV !== "development" ? undefined : {
+        introduced: "higher@1.0.0",
+        expects: (`
+            The constructor expects a number indicating ngram size and one
+            sequence as input. Ngram size must be a positive integer.
+        `),
+    },
+    getSequence: process.env.NODE_ENV !== "development" ? undefined : [
+        hi => new TrackingNgramSequence(1, hi.emptySequence()),
+        hi => new TrackingNgramSequence(3, hi.emptySequence()),
+        hi => new TrackingNgramSequence(1, hi.range(1)),
+        hi => new TrackingNgramSequence(3, hi.range(1)),
+        hi => new TrackingNgramSequence(1, hi.range(2)),
+        hi => new TrackingNgramSequence(2, hi.range(2)),
+        hi => new TrackingNgramSequence(3, hi.range(2)),
+        hi => new TrackingNgramSequence(2, hi.range(3)),
+        hi => new TrackingNgramSequence(3, hi.range(3)),
+        hi => new TrackingNgramSequence(4, hi.range(3)),
+        hi => new TrackingNgramSequence(3, hi("some string")),
+        hi => new TrackingNgramSequence(2, hi.repeat("hello")),
+        hi => new TrackingNgramSequence(4, hi.counter()),
+    ],
     constructor: function TrackingNgramSequence(
         ngramSize, source, currentNgram = undefined
     ){
+        // TODO: Better arguments validation
+        if(ngramSize < 1) throw new Error("Ngram size must be at least 1.");
         this.ngramSize = ngramSize;
         this.source = source;
         this.currentNgram = currentNgram;
@@ -102,11 +160,13 @@ export const TrackingNgramSequence = Sequence.extend({
         return this.source.done() && this.currentNgram.length < this.ngramSize;
     },
     length: function(){
-        return 1 + this.source.length() - this.ngramSize;
+        const length = 1 + this.source.length() - this.ngramSize;
+        return length >= 0 ? length : 0;
     },
     left: function(){
         if(!this.currentNgram) this.initialize();
-        return (this.currentNgram.length >= this.ngramSize) + this.source.left();
+        const left = (this.currentNgram.length >= this.ngramSize) + this.source.left();
+        return left >= 0 ? left : 0;
     },
     front: function(){
         if(!this.currentNgram) this.initialize();
@@ -156,10 +216,6 @@ export const ngrams = wrap({
     name: "ngrams",
     attachSequence: true,
     async: false,
-    sequences: [
-        SlicingNgramSequence,
-        TrackingNgramSequence
-    ],
     arguments: {
         unordered: {
             numbers: 1,
@@ -174,6 +230,38 @@ export const ngrams = wrap({
         }else{
             return new TrackingNgramSequence(ngramSize, source);
         }
+    },
+    tests: process.env.NODE_ENV !== "development" ? undefined : {
+        "basicUsage": hi => {
+            const words = ["hello", "world", "how", "do?"];
+            hi.assertEqual(hi.ngrams(2, words), [ // Bigrams
+                ["hello", "world"], ["world", "how"], ["how", "do?"]
+            ]);
+            hi.assertEqual(hi.ngrams(3, words), [ // Trigrams
+                ["hello", "world", "how"], ["world", "how", "do?"]
+            ]);
+        },
+        "emptyInput": hi => {
+            hi.assertEmpty(hi.emptySequence().ngrams(1));
+            hi.assertEmpty(hi.emptySequence().ngrams(3));
+            hi.assertEmpty(hi.emptySequence().ngrams(100));
+        },
+        "unboundedInput": hi => {
+            const seq = hi.counter().ngrams(2);
+            hi.assert(seq.startsWith(hi.isEqual, [[0, 1], [1, 2], [2, 3], [3, 4]]));
+        },
+        "singleLengthNgrams": hi => {
+            hi.assertEqual(hi.ngrams(1, [1, 2, 3]), [[1], [2], [3]]);
+        },
+        "zeroLengthNgrams": hi => {
+            const seq = hi.ngrams(0, [1, 2, 3]);
+            hi.assert(seq.unbounded());
+            hi.assert(seq.startsWith(hi.isEqual, [[], [], []]));
+        },
+        "tooBigNgrams": hi => {
+            hi.assertEmpty(hi.ngrams(4, [1, 2, 3]));
+            hi.assertEmpty(hi.ngrams(2, hi.emptySequence()));
+        },
     },
 });
 

--- a/src/functions/trigrams.js
+++ b/src/functions/trigrams.js
@@ -21,6 +21,21 @@ export const trigrams = wrap({
             return new TrackingNgramSequence(3, source);
         }
     },
+    tests: process.env.NODE_ENV !== "development" ? undefined : {
+        "basicUsage": hi => {
+            const words = ["hello", "world", "how", "do?"];
+            hi.assertEqual(hi.trigrams(words), [
+                ["hello", "world", "how"], ["world", "how", "do?"]
+            ]);
+        },
+        "emptyInput": hi => {
+            hi.assertEmpty(hi.emptySequence().trigrams());
+        },
+        "unboundedInput": hi => {
+            const seq = hi.counter().trigrams();
+            hi.assert(seq.startsWith(hi.isEqual, [[0, 1, 2], [1, 2, 3], [2, 3, 4]]));
+        },
+    },
 });
 
 export default trigrams;


### PR DESCRIPTION
Could use some additional test coverage but this is good enough for now

Fixed an issue with sequence lengths when the ngrams sequence had a longer ngram length than the input sequence was long