### PR TITLE
Tests and docs for any, all, none, anyPass, allPass, nonePass

### DIFF
--- a/src/core/wrap.js
+++ b/src/core/wrap.js
@@ -36,6 +36,12 @@ export const wrap = lightWrap({
                     }else if(unordered[type].optional){
                         unordered[type].amount = "?";
                         unordered[type].order = [unordered[type].optional];
+                    }else if(unordered[type].anyNumberOf){
+                        unordered[type].amount = "*";
+                        unordered[type].all = unordered[type].anyNumberOf;
+                    }else if(unordered[type].atLeastOne){
+                        unordered[type].amount = "+";
+                        unordered[type].all = unordered[type].atLeastOne;
                     }else{
                         unordered[type] = {amount: unordered[type]};
                     }

--- a/src/functions/all.js
+++ b/src/functions/all.js
@@ -11,38 +11,46 @@ export const all = wrap({
             Get whether all the elements in an input sequence satisfy an
             optional predicate or, if no predicate was provided, whether all
             the elements of the input are truthy.
+            Behaves like the \`&&\` operator.
         `),
         expects: (`
-            The function expects as input a sequence known to be bounded and
+            The function expects as input a known-bounded sequence and
             an optional predicate function to apply to each element.
         `),
         returns: (`
-            The function returns @true when all the elements in the sequence
-            satisfied the predicate or, if no predicate was given, if all the
-            elements were truthy.
-            It also returns @true if the sequence was empty.
-            The function returns the first falsey element otherwise.
+            The function returns the first falsey element or, if there was no
+            falsey element, the last truthy element when no predicate was given.
+            It returns the first falsey predicate return value or, if the
+            predicate was satisfied by every element, the last truthy
+            return value when a predicate was specified.
+            The function returns #true when the input sequence was empty.
         `),
         returnType: {
             "typeof first falsey element": (`
                 When no predicate was given and any element of the input
                 sequence was falsey.
             `),
-            "false": (`
+            "typeof last truthy element": (`
+                When no predicate was given and no element of the sequence
+                was falsey, but there was at least one element in the sequence.
+            `),
+            "typeof first falsey predicate return value": (`
                 When a predicate was given and any element of the input
-                sequence did not satisfy the predicate.
+                failed to satisfy the predicate.
+            `),
+            "typeof last truthy predicate return value": (`
+                When a predicate was given and every element of the input
+                satisfied the predicate.
             `),
             "true": (`
-                When no predicate was given and all elements of the input
-                were truthy, or when a predicate was given and all elements
-                satisfied it, or when the input sequence was empty.
+                When the input sequence was empty.
             `),
         },
         examples: [
             "basicUsage", "basicUsagePredicate",
         ],
         related: [
-            "any", "none",
+            "any", "none", "allPass",
         ],
     },
     attachSequence: true,
@@ -55,15 +63,20 @@ export const all = wrap({
     },
     implementation: (predicate, source) => {
         if(predicate){
+            let result = true;
             for(const element of source){
-                if(!predicate(element)) return false;
+                result = predicate(element);
+                if(!result) return result;
             }
+            return result;
         }else{
+            let lastElement = true;
             for(const element of source){
                 if(!element) return element;
+                lastElement = element;
             }
+            return lastElement;
         }
-        return true;
     },
     tests: {
         "basicUsage": hi => {
@@ -94,6 +107,21 @@ export const all = wrap({
         },
         "unboundedInput": hi => {
             hi.assertFail(() => hi.counter().all(i => i < 100));
+        },
+        "returnsFirstFalsey": hi => {
+            const firstElement = i => i && i[0];
+            hi.assert(hi.all([0, 0, 1, true]) === 0);
+            hi.assert(hi.all(["hello", null, 0]) === null);
+            hi.assert(hi.all([true, 1, false, 1, 0]) === false);
+            hi.assert(hi.all(firstElement, [[1], [1], [false], [1]]) === false);
+            hi.assert(hi.all(firstElement, [["x"], ["y"], ["z"], [null]]) === null);
+        },
+        "returnsLastTruthy": hi => {
+            const firstElement = i => i && i[0];
+            hi.assert(hi.all([true, 1]) === 1);
+            hi.assert(hi.all([1, "yes", Infinity]) === Infinity);
+            hi.assert(hi.all(firstElement, [[1], [true], [100]]) === 100);
+            hi.assert(hi.all(firstElement, [[1], [1], ["hello"]]) === "hello");
         },
     },
 });

--- a/src/functions/anyPass.js
+++ b/src/functions/anyPass.js
@@ -3,16 +3,42 @@ import {wrap} from "../core/wrap";
 // Get a predicate that passes when at least one of the given predicates pass.
 export const anyPass = wrap({
     name: "anyPass",
+    summary: "Get a predicate that passes when any of the input predicates pass.",
+    docs: process.env.NODE_ENV !== "development" ? undefined : {
+        introduced: "higher@1.0.0",
+        expects: (`
+            The function expects any number of predicate functions as input.
+        `),
+        returns: (`
+            The function returns a predicate function which is satisfied by an
+            input when at least one of the input predicates was satisfied.
+            When there were no input predicates, the output predicate returns
+            #undefined for all inputs. Behaves like the \`||\` operator.
+        `),
+        developers: (`
+            The outputted predicate function evaluates the input predicates in
+            order from first to last and, the first time that any predicate
+            produces a truthy value, the function then returns that produced
+            value without evaluating any more predicates.
+        `),
+        returnType: "function",
+        examples: [
+            "basicUsage",
+        ],
+        related: [
+            "allPass", "nonePass", "any",
+        ],
+    },
     attachSequence: false,
     async: false,
     arguments: {
         unordered: {
-            functions: "*"
-        }
+            functions: {anyNumberOf: wrap.expecting.predicate},
+        },
     },
     implementation: (predicates) => {
         if(predicates.length === 0){
-            return () => false;
+            return () => undefined;
         }else if(predicates.length === 1){
             return predicates[0];
         }else if(predicates.length === 2){
@@ -21,12 +47,90 @@ export const anyPass = wrap({
             return (...args) => (a(...args) || b(...args));
         }else{
             return (...args) => {
+                let result = undefined;
                 for(const predicate of predicates){
-                    if(predicate(...args)) return true;
+                    result = predicate(...args);
+                    if(result) return result;
                 }
-                return false;
+                return result;
             };
         }
+    },
+    tests: process.env.NODE_ENV !== "development" ? undefined : {
+        "basicUsage": hi => {
+            const even = i => i % 2 === 0;
+            const positive = i => i > 0;
+            const evenOrPositive = hi.anyPass(even, positive);
+            hi.assert(evenOrPositive(2));
+            hi.assert(evenOrPositive(3));
+            hi.assert(evenOrPositive(-4));
+            hi.assertNot(evenOrPositive(-5));
+        },
+        "noInputs": hi => {
+            const pred = hi.anyPass();
+            hi.assertNot(pred(true));
+            hi.assertNot(pred(false));
+            hi.assertNot(pred(1));
+            hi.assertNot(pred(undefined));
+        },
+        "oneInput": hi => {
+            const even = i => i % 2 === 0;
+            hi.assert(hi.anyPass(even) === even);
+        },
+        "twoInputs": hi => {
+            const a = (i) => (i[0] === "h");
+            const b = (i) => (i[1] === "e");
+            const pred = hi.anyPass(a, b);
+            hi.assert(pred("hello"));
+            hi.assert(pred("helium"));
+            hi.assert(pred("hi"));
+            hi.assert(pred("me"));
+            hi.assertNot(pred(""));
+            hi.assertNot(pred("boop"));
+        },
+        "threeInputs": hi => {
+            const a = i => i[0] === "a";
+            const b = i => i[0] === "b";
+            const c = i => i[0] === "c";
+            const pred = hi.anyPass(a, b, c);
+            hi.assert(pred("apple"));
+            hi.assert(pred("banana"));
+            hi.assert(pred("cherry"));
+            hi.assertNot(pred("mango"));
+            hi.assertNot(pred("pear"));
+        },
+        "noInputsSatisfied": hi => {
+            const never = i => false;
+            const pred = hi.anyPass(never, never, never, never);
+            hi.assertNot(pred(true));
+            hi.assertNot(pred(false));
+            hi.assertNot(pred(1));
+            hi.assertNot(pred(undefined));
+        },
+        "returnsFirstTruthy": hi => {
+            const firstElement = i => i && i[0];
+            const testProperty = i => i && i.test;
+            const lengthProperty = i => i && i.length;
+            const pred2 = hi.anyPass(firstElement, testProperty);
+            hi.assert(pred2(["hello"]) === "hello");
+            hi.assert(pred2({test: 1}) === 1);
+            const pred3 = hi.anyPass(firstElement, testProperty, lengthProperty);
+            hi.assert(pred3(["hello"]) === "hello");
+            hi.assert(pred3({test: 1}) === 1);
+            hi.assert(pred3([0, 1, 2, 3]) === 4);
+        },
+        "returnsLastFalsey": hi => {
+            const never = i => false;
+            const modThree = i => [false, null, undefined][i];
+            const pred2 = hi.anyPass(never, modThree);
+            hi.assert(pred2(0) === false);
+            hi.assert(pred2(1) === null);
+            hi.assert(pred2(2) === undefined);
+            const pred4 = hi.anyPass(never, never, never, modThree);
+            hi.assert(pred4(0) === false);
+            hi.assert(pred4(1) === null);
+            hi.assert(pred4(2) === undefined);
+        },
     },
 });
 

--- a/src/functions/none.js
+++ b/src/functions/none.js
@@ -13,15 +13,14 @@ export const none = wrap({
             the elements of the input are falsey.
         `),
         expects: (`
-            The function expects as input a sequence known to be bounded and
+            The function expects as input a known-bounded sequence and
             an optional predicate function to apply to each element.
         `),
         returns: (`
-            The function returns @true when no elements in the sequence
-            satisfied the predicate or, if no predicate was given, if none of
-            the elements were truthy.
-            It also returns @true if the sequence was empty.
-            The function returns @false otherwise.
+            The function returns #false when any element in the sequence
+            satisfied the predicate or, if no predicate was given, if any
+            of the elements were truthy. The function returns #true otherwise,
+            including if the input sequence was empty.
         `),
         returnType: {
             "false": (`
@@ -39,7 +38,7 @@ export const none = wrap({
             "basicUsage", "basicUsagePredicate",
         ],
         related: [
-            "all", "none",
+            "all", "none", "nonePass",
         ],
     },
     attachSequence: true,

--- a/src/functions/nonePass.js
+++ b/src/functions/nonePass.js
@@ -1,21 +1,45 @@
 import {wrap} from "../core/wrap";
 
-// Get a predicate that passes when none of the given predicates pass.
-// Functionally equivalent to negate(anyPass(...predicates)).
 export const nonePass = wrap({
     name: "nonePass",
+    summary: "Get a predicate that passes when none of the input predicates pass.",
+    docs: process.env.NODE_ENV !== "development" ? undefined : {
+        introduced: "higher@1.0.0",
+        expects: (`
+            The function expects any number of predicate functions as input.
+        `),
+        returns: (`
+            The function returns a predicate function which is satisfied by an
+            input when at none of the input predicates were satisfied.
+            When there were no input predicates, the output predicate returns
+            #true for all inputs.
+        `),
+        developers: (`
+            The outputted predicate function evaluates the input predicates in
+            order from first to last and, the first time that any predicate
+            produces a truthy value, the function then returns #false without
+            evaluating any more predicates.
+        `),
+        returnType: "function",
+        examples: [
+            "basicUsage",
+        ],
+        related: [
+            "anyPass", "allPass", "none",
+        ],
+    },
     attachSequence: false,
     async: false,
     arguments: {
         unordered: {
-            functions: "*"
-        }
+            functions: {anyNumberOf: wrap.expecting.predicate},
+        },
     },
     implementation: (predicates) => {
         if(predicates.length === 0){
             return () => true;
         }else if(predicates.length === 1){
-            return predicates[0];
+            return (...args) => (!predicates[0](...args));
         }else if(predicates.length === 2){
             const a = predicates[0];
             const b = predicates[1];
@@ -28,6 +52,62 @@ export const nonePass = wrap({
                 return true;
             };
         }
+    },
+    tests: process.env.NODE_ENV !== "development" ? undefined : {
+        "basicUsage": hi => {
+            const even = i => i % 2 === 0;
+            const positive = i => i > 0;
+            const nethierEvenNorPositive = hi.nonePass(even, positive);
+            hi.assertNot(nethierEvenNorPositive(2));
+            hi.assertNot(nethierEvenNorPositive(3));
+            hi.assertNot(nethierEvenNorPositive(-4));
+            hi.assert(nethierEvenNorPositive(-5));
+        },
+        "noInputs": hi => {
+            const pred = hi.nonePass();
+            hi.assert(pred(true));
+            hi.assert(pred(false));
+            hi.assert(pred(1));
+            hi.assert(pred(undefined));
+        },
+        "oneInput": hi => {
+            const even = i => i % 2 === 0;
+            const pred = hi.nonePass(even);
+            hi.assert(pred(3));
+            hi.assert(pred(5));
+            hi.assertNot(pred(2));
+            hi.assertNot(pred(4));
+        },
+        "twoInputs": hi => {
+            const a = (i) => (i[0] === "h");
+            const b = (i) => (i[1] === "e");
+            const pred = hi.nonePass(a, b);
+            hi.assertNot(pred("hello"));
+            hi.assertNot(pred("helium"));
+            hi.assertNot(pred("hi"));
+            hi.assertNot(pred("me"));
+            hi.assert(pred(""));
+            hi.assert(pred("boop"));
+        },
+        "threeInputs": hi => {
+            const a = i => i[0] === "a";
+            const b = i => i[0] === "b";
+            const c = i => i[0] === "c";
+            const pred = hi.nonePass(a, b, c);
+            hi.assertNot(pred("apple"));
+            hi.assertNot(pred("banana"));
+            hi.assertNot(pred("cherry"));
+            hi.assert(pred("mango"));
+            hi.assert(pred("pear"));
+        },
+        "noInputsSatisfied": hi => {
+            const never = i => false;
+            const pred = hi.nonePass(never, never, never, never);
+            hi.assert(pred(true));
+            hi.assert(pred(false));
+            hi.assert(pred(1));
+            hi.assert(pred(undefined));
+        },
     },
 });
 


### PR DESCRIPTION
Added new and improved existing

Tweaked behavior of `any`, `all`, `anyPass`, `allPass` to be more like the `||` and `&&` js operators