### PR TITLE
Add containsElement overrides for repeat and repeatElement sequences

### DIFF
--- a/src/functions/containsElement.js
+++ b/src/functions/containsElement.js
@@ -30,7 +30,7 @@ export const containsElement = wrap({
     },
     implementation: (source, element) => {
         for(const sourceElement of source){
-            if(isEqual(element, sourceElement)) return true;
+            if(isEqual(sourceElement, element)) return true;
         }
         return false;
     },
@@ -48,7 +48,8 @@ export const containsElement = wrap({
             hi.assertNot(hi.emptySequence().containsElement(null));
         },
         "unboundedInput": hi => {
-            hi.assertFail(() => hi.repeat("!?").containsElement("x"));
+            const seq = hi.recur(i => i + "!").seed("ok");
+            hi.assertFail(() => seq.containsElement("x"));
         },
     },
 });

--- a/src/functions/repeat.js
+++ b/src/functions/repeat.js
@@ -1,6 +1,7 @@
 import {Sequence} from "../core/sequence";
 import {wrap} from "../core/wrap";
 
+import {containsElement} from "./containsElement";
 import {copyable} from "./copyable";
 import {DistinctSequence, defaultDistinctTransform} from "./distinct";
 import {EmptySequence} from "./emptySequence";
@@ -10,7 +11,7 @@ export const FiniteRepeatSequence = Sequence.extend({
         "copy",
     ],
     overrides: [
-        "repeat", "distinct",
+        "repeat", "distinct", "containsElement",
     ],
     docs: process.env.NODE_ENV !== "development" ? undefined : {
         introduced: "higher@1.0.0",
@@ -37,6 +38,11 @@ export const FiniteRepeatSequence = Sequence.extend({
         "distinctOverride": hi => {
             const seq = new hi.sequence.FiniteRepeatSequence(3, hi("hello"));
             hi.assertEqual(seq.distinct(), "helo");
+        },
+        "containsElementOverride": hi => {
+            const seq = () => new hi.sequence.FiniteRepeatSequence(5, hi([1, 2, 3, 4]));
+            hi.assert(seq().containsElement(2));
+            hi.assertNot(seq().containsElement(NaN));
         },
     },
     getSequence: process.env.NODE_ENV !== "development" ? undefined : [
@@ -91,6 +97,9 @@ export const FiniteRepeatSequence = Sequence.extend({
         return new DistinctSequence(
             transform || defaultDistinctTransform, this.source
         );
+    },
+    containsElement: function(element){
+        return containsElement(this.source, element);
     },
     repetitions: function(){
         return this.targetRepetitions;
@@ -239,11 +248,11 @@ export const FiniteRepeatSequence = Sequence.extend({
 });
 
 export const InfiniteRepeatSequence = Sequence.extend({
-    overrides: [
-        "repeat", "distinct",
-    ],
     supportRequired: [
         "copy",
+    ],
+    overrides: [
+        "repeat", "distinct", "containsElement",
     ],
     tests: process.env.NODE_ENV !== "development" ? undefined : {
         "repeatOverride": hi => {
@@ -256,6 +265,11 @@ export const InfiniteRepeatSequence = Sequence.extend({
         "distinctOverride": hi => {
             const seq = new hi.sequence.InfiniteRepeatSequence(hi("hello"));
             hi.assertEqual(seq.distinct(), "helo");
+        },
+        "containsElementOverride": hi => {
+            const seq = () => new hi.sequence.InfiniteRepeatSequence(hi([1, 2, 3, 4]));
+            hi.assert(seq().containsElement(2));
+            hi.assertNot(seq().containsElement(NaN));
         },
     },
     getSequence: process.env.NODE_ENV !== "development" ? undefined : [
@@ -284,6 +298,9 @@ export const InfiniteRepeatSequence = Sequence.extend({
         return new DistinctSequence(
             transform || defaultDistinctTransform, this.source
         );
+    },
+    containsElement: function(element){
+        return containsElement(this.source, element);
     },
     repetitions: () => Infinity,
     bounded: () => false,

--- a/src/functions/repeatElement.js
+++ b/src/functions/repeatElement.js
@@ -1,3 +1,4 @@
+import {isEqual} from "../core/isEqual";
 import {Sequence} from "../core/sequence";
 import {wrap} from "../core/wrap";
 
@@ -8,7 +9,7 @@ import {defaultDistinctTransform} from "./distinct";
 
 export const FiniteRepeatElementSequence = Sequence.extend({
     overrides: [
-        "repeat", "distinct", "uniq",
+        "repeat", "distinct", "uniq", "containsElement",
     ],
     tests: process.env.NODE_ENV !== "development" ? undefined : {
         "repeatOverride": hi => {
@@ -36,6 +37,11 @@ export const FiniteRepeatElementSequence = Sequence.extend({
             hi.assertEqual(seq.uniq(), [0]);
             const uniqSeq = seq.uniq((a, b) => false);
             hi.assertEqual(uniqSeq, [0, 0, 0, 0]);
+        },
+        "containsElementOverride": hi => {
+            const seq = new hi.sequence.FiniteRepeatElementSequence(3, "!");
+            hi.assert(seq.containsElement("!"));
+            hi.assertNot(seq.containsElement("."));
         },
     },
     constructor: function FiniteRepeatElementSequence(
@@ -66,6 +72,9 @@ export const FiniteRepeatElementSequence = Sequence.extend({
         }else{
             return this;
         }
+    },
+    containsElement: function(element){
+        return isEqual(element, this.element);
     },
     repetitions: function(){
         return this.targetRepetitions();
@@ -124,7 +133,7 @@ export const FiniteRepeatElementSequence = Sequence.extend({
 
 export const InfiniteRepeatElementSequence = Sequence.extend({
     overrides: [
-        "repeat", "distinct", "uniq",
+        "repeat", "distinct", "uniq", "containsElement",
     ],
     tests: process.env.NODE_ENV !== "development" ? undefined : {
         "repeatOverride": hi => {
@@ -149,6 +158,11 @@ export const InfiniteRepeatElementSequence = Sequence.extend({
             hi.assert(uniqSeq.unbounded());
             hi.assert(uniqSeq.startsWith([0, 0, 0, 0, 0]));
         },
+        "containsElementOverride": hi => {
+            const seq = new hi.sequence.FiniteRepeatElementSequence(3, "!");
+            hi.assert(seq.containsElement("!"));
+            hi.assertNot(seq.containsElement("."));
+        },
     },
     constructor: function InfiniteRepeatElementSequence(element){
         this.element = element;
@@ -170,6 +184,9 @@ export const InfiniteRepeatElementSequence = Sequence.extend({
         }else{
             return this;
         }
+    },
+    containsElement: function(element){
+        return isEqual(element, this.element);
     },
     repetitions: () => Infinity,
     seed: function(element){


### PR DESCRIPTION
For finite repeat sequences this is a more performant implementation and for infinite repeat sequences this makes the operation newly possible