### PR TITLE
dropLast now accepts more sequence inputs and is more lazy

### DIFF
--- a/src/functions/dropLast.js
+++ b/src/functions/dropLast.js
@@ -1,14 +1,191 @@
 import {defineSequence} from "../core/defineSequence";
 import {wrap} from "../core/wrap";
 
-import {BoundsUnknownError} from "../errors/BoundsUnknownError";
-
-import {ArraySequence} from "./arrayAsSequence";
 import {EmptySequence} from "./emptySequence";
 import {FilterSequence} from "./filter";
 import {HeadSequence} from "./head";
-import {OnDemandSequence} from "./onDemandSequence";
-import {ReverseSequence} from "./reverse";
+
+export const DropLastSequence = defineSequence({
+    summary: "Enumerate the contents of a sequence, omitting the last so many elements.",
+    constructor: function DropLastSequence(
+        dropTarget, source, seenElements = undefined
+    ){
+        this.dropTarget = dropTarget;
+        this.source = source;
+        this.seenElements = seenElements || [];
+        this.maskAbsentMethods(source);
+    },
+    initialize: function(){
+        while(this.seenElements.length < this.dropTarget && !this.source.done()){
+            this.seenElements.push(this.source.nextFront());
+        }
+        this.done = function(){
+            return this.source.done();
+        };
+        this.front = function(){
+            return this.seenElements[0];
+        };
+        this.popFront = function(){
+            this.seenElements.shift();
+            this.seenElements.push(this.source.nextFront());
+        };
+    },
+    bounded: function(){
+        return this.source.bounded();
+    },
+    unbounded: function(){
+        // Use UnboundedDropLastSequence instead when source is known-unbounded!
+        return this.source.unbounded();
+    },
+    done: function(){
+        this.initialize();
+        return this.source.done();
+    },
+    length: function(){
+        return Math.max(0, this.source.length() - this.dropTarget);
+    },
+    left: function(){
+        return Math.max(0, this.source.left() - this.dropTarget);
+    },
+    front: function(){
+        this.initialize();
+        return this.seenElements[0];
+    },
+    popFront: function(){
+        this.initialize();
+        return this.popFront();
+    },
+    index: function(i){
+        return this.source.index(i);
+    },
+    slice: function(i, j){
+        return this.source.slice(i, j);
+    },
+    copy: function(){
+        const copy = new DropLastSequence(
+            this.dropTarget, this.source.copy(), this.seenElements.slice()
+        );
+        copy.done = this.done;
+        copy.front = this.front;
+        copy.popFront = this.popFront;
+        return copy;
+    },
+    reset: function(){
+        this.source.reset();
+        delete this.done;
+        delete this.front;
+        delete this.popFront;
+        return this;
+    },
+});
+
+export const DropLastPredicateSequence = defineSequence({
+    summary: "Enumerate the contents of a sequence, omitting the last so many elements satisfying a predicate.",
+    constructor: function DropLastPredicateSequence(
+        dropTarget, predicate, source, frontIndex = undefined,
+        seenElements = undefined, seenSatisfied = undefined
+    ){
+        this.dropTarget = dropTarget;
+        this.predicate = predicate;
+        this.source = source;
+        this.frontIndex = frontIndex || 0;
+        this.seenElements = seenElements || [];
+        this.seenSatisfied = seenSatisfied || [];
+        this.maskAbsentMethods(source);
+    },
+    initialize: function(){
+        while(this.seenSatisfied.length <= this.dropTarget && !this.source.done()){
+            const element = this.source.nextFront();
+            if(this.predicate(element)){
+                this.seenSatisfied.push(this.frontIndex);
+            }
+            this.seenElements.push(element);
+            this.frontIndex++;
+        }
+        if(this.source.done()){
+            while(this.seenSatisfied[0] === this.frontIndex - this.seenElements.length){
+                this.seenSatisfied.shift();
+                this.seenElements.shift();
+            }
+        }
+        this.done = function(){
+            return this.seenElements.length === 0 && this.source.done();
+        };
+        this.front = function(){
+            return this.seenElements[0];
+        };
+        this.popFront = function(){
+            // Remove the element just viewed
+            this.seenElements.shift();
+            // While the source has yet to be fully consumed...
+            if(!this.source.done()){
+                const element = this.source.nextFront();
+                if(this.predicate(element)){
+                    this.seenSatisfied.shift();
+                    this.seenSatisfied.push(this.frontIndex);
+                }
+                this.seenElements.push(element);
+                this.frontIndex++;
+                if(this.seenSatisfied[0] <= this.frontIndex - this.seenElements.length - 1){
+                    this.seenSatisfied.shift();
+                    while(this.seenSatisfied.length <= this.dropTarget && !this.source.done()){
+                        const nextElement = this.source.nextFront();
+                        if(this.predicate(nextElement)){
+                            this.seenSatisfied.push(this.frontIndex);
+                        }
+                        this.seenElements.push(nextElement);
+                        this.frontIndex++;
+                    }
+                }else if(this.source.done()){
+                    this.seenSatisfied.shift();
+                }
+            }
+            // After the source was consumed and the last elements are being enumerated...
+            if(this.source.done()){
+                while(this.seenSatisfied[0] === this.frontIndex - this.seenElements.length){
+                    this.seenSatisfied.shift();
+                    this.seenElements.shift();
+                }
+            }
+        };
+    },
+    bounded: function(){
+        return this.source.bounded();
+    },
+    unbounded: function(){
+        // Use UnboundedDropLastPredicateSequence instead when source is known-unbounded!
+        return this.source.unbounded();
+    },
+    done: function(){
+        this.initialize();
+        return this.seenElements.length === 0 && this.source.done();
+    },
+    front: function(){
+        this.initialize();
+        return this.seenElements[0];
+    },
+    popFront: function(){
+        this.initialize();
+        return this.popFront();
+    },
+    copy: function(){
+        const copy = new DropLastPredicateSequence(
+            this.dropTarget, this.predicate, this.source.copy(),
+            this.frontIndex, this.seenElements.slice(), this.seenSatisfied.slice()
+        );
+        copy.done = this.done;
+        copy.front = this.front;
+        copy.popFront = this.popFront;
+        return copy;
+    },
+    reset: function(){
+        this.source.reset();
+        delete this.done;
+        delete this.front;
+        delete this.popFront;
+        return this;
+    },
+});
 
 export const UnboundedDropLastSequence = defineSequence({
     summary: "Enumerate the contents of an unbounded sequence, omitting the last so many elements.",
@@ -188,44 +365,6 @@ export const UnboundedDropLastPredicateSequence = defineSequence({
     },
 });
 
-// Implement dropLast with a predicate for known-bounded sequence inputs
-const DropLastOnDemandSequence = (dropTarget, predicate, source) => {
-    return new OnDemandSequence({
-        bounded: () => true,
-        unbounded: () => false,
-        dump: () => {
-            const array = [];
-            let dropped = 0;
-            if(source.back){
-                while(!source.done()){
-                    const element = source.nextBack();
-                    if(predicate(element)){
-                        dropped++;
-                        if(dropped >= dropTarget) break;
-                    }else{
-                        array.push(element);
-                    }
-                }
-                while(!source.done()){
-                    array.push(source.nextBack());
-                }
-                return new ReverseSequence(new ArraySequence(array));
-            }else{
-                for(const element of source){
-                    array.push(element);
-                }
-                for(let i = array.length - 1; i >= 0 && dropped < dropTarget; i--){
-                    if(predicate(array[i])){
-                        array.splice(i, 1);
-                        dropped++;
-                    }
-                }
-                return new ArraySequence(array);
-            }
-        },
-    });
-};
-
 export const dropLast = wrap({
     name: "dropLast",
     summary: "Get a sequence minus the last so many elements.",
@@ -234,7 +373,6 @@ export const dropLast = wrap({
         expects: (`
             The function expects as input a sequence, an optional number of
             elements to drop from its back, and an optional predicate function.
-            The input sequence must be either known-bounded or known-unbounded.
         `),
         returns: (`
             The function returns a sequence which enumerates the elements in
@@ -243,6 +381,13 @@ export const dropLast = wrap({
             /When no number of elements was specified, #1 is used as a default.
             When no predicate was specified, the output behaves as though a
             predicate satisfied by every input was given.
+        `),
+        warnings: (`
+            When given a predicate function as input and an in-fact unbounded
+            sequence that is not known-unbounded and which ever ceases to
+            enumerate any more elements satisfying the predicate, attempting
+            to even partially consume the returned sequence may produce an
+            infinite loop.
         `),
         returnType: "sequence",
         examples: [
@@ -258,7 +403,7 @@ export const dropLast = wrap({
         unordered: {
             numbers: "?",
             functions: {optional: wrap.expecting.predicate},
-            sequences: {one: wrap.expecting.knownBoundsSequence},
+            sequences: 1,
         }
     },
     implementation: (dropTarget, predicate, source) => {
@@ -273,14 +418,14 @@ export const dropLast = wrap({
         }else if(predicate){
             if(source.length && source.length() <= dropTarget){
                 return new FilterSequence(element => !predicate(element), source);
-            }else if(source.bounded()){
-                return DropLastOnDemandSequence(drop, predicate, source);
             }else if(source.unbounded()){
-                return new UnboundedDropLastPredicateSequence(drop, predicate, source);
+                if(source.back){
+                    return new UnboundedDropLastPredicateSequence(drop, predicate, source);
+                }else{
+                    return source;
+                }
             }else{
-                throw BoundsUnknownError(source, {
-                    message: "Failed to drop last elements",
-                });
+                return new DropLastPredicateSequence(drop, predicate, source);
             }
         }else if(source.length){
             const sourceLength = source.length();
@@ -291,19 +436,14 @@ export const dropLast = wrap({
                     new HeadSequence(sourceLength - drop, source)
                 )
             );
-        }else if(source.bounded()){
-            return new OnDemandSequence({
-                dump: () => {
-                    const array = [];
-                    for(const element of source) array.push(element);
-                    return (array.length <= dropTarget ?
-                        new EmptySequence() :
-                        new ArraySequence(array).slice(0, array.length - dropTarget)
-                    );
-                },
-            });
-        }else{ // Argument validation implies source.unbounded()
-            return new UnboundedDropLastSequence(drop, source);
+        }else if(source.unbounded()){
+            if(source.back){
+                return new UnboundedDropLastSequence(drop, source);
+            }else{
+                return source;
+            }
+        }else{
+            return new DropLastSequence(drop, source);
         }
     },
     tests: process.env.NODE_ENV !== "development" ? undefined : {
@@ -367,6 +507,13 @@ export const dropLast = wrap({
             hi.assert(seq.startsWith([1, 3, 5, 1, 3, 5]));
             hi.assert(seq.endsWith([1, 3, 5, 1, 3, 5]));
         },
+        "unboundedUnidirectionalInput": hi => {
+            const seq = hi.recur(i => i + 1).seed(0);
+            hi.assertUndefined(seq.back);
+            hi.assert(seq.dropLast(10) === seq);
+            hi.assert(seq.dropLast(10, i => true) === seq);
+            hi.assert(seq.dropLast(Infinity, i => i % 2 === 0).startsWith([1, 3, 5, 7]));
+        },
         "unidirectionalKnownLengthInput": hi => {
             const seq = () => hi.counter().until(i => i >= 8).assumeLength(8);
             const even = i => i % 2 === 0;
@@ -398,9 +545,10 @@ export const dropLast = wrap({
             hi.assertEqual(seq().dropLast(Infinity, even), [1, 3, 5, 7]);
         },
         "notKnownBoundedInput": hi => {
-            const seq = hi.counter().until(i => i >= 8);
-            hi.assertFail(() => seq.dropLast(1));
-            hi.assertFail(() => seq.dropLast(1, i => i !== 5));
+            const seq = () => hi.counter().until(i => i >= 8);
+            hi.assertEqual(seq().dropLast(2), [0, 1, 2, 3, 4, 5]);
+            hi.assertEqual(seq().dropLast(2, i => i % 2 === 0), [0, 1, 2, 3, 5, 7]);
+            hi.assertEqual(seq().dropLast(2, i => i % 2 !== 0), [0, 1, 2, 3, 4, 6]);
         },
     },
 });


### PR DESCRIPTION
Probably less performant than the previous implementation when you really just wanted the whole result, but will be considerably more performant when the sequence needs to only be partially consumed, and also allows sequences with unknown boundedness to be accepted