### PR TITLE
Sequence converter order based on before/after instead of numbers

### DIFF
--- a/src/core/defineSequence.js
+++ b/src/core/defineSequence.js
@@ -14,6 +14,7 @@ import {cleanDocs, cleanString} from "../docs/cleanString";
 
 export const sequenceTypes = {};
 
+// TODO: Thoroughly document sequence type creation somewhere
 export const defineSequence = lightWrap({
     summary: "Extend the @Sequence prototype.",
     docs: process.env.NODE_ENV !== "development" ? undefined : {

--- a/src/core/wrap.js
+++ b/src/core/wrap.js
@@ -66,9 +66,11 @@ export const wrap = lightWrap({
             attachSequenceMethods(fancy);
         }
         if(info.asSequence){
-            const converter = Object.assign(
-                {transform: info.implementation}, info.asSequence
-            );
+            const converterData = {
+                name: fancy.name,
+                transform: info.implementation
+            };
+            const converter = Object.assign(converterData, info.asSequence);
             addSequenceConverter(converter);
         }
         if(process.env.NODE_ENV === "development"){

--- a/src/functions/arrayAsSequence.js
+++ b/src/functions/arrayAsSequence.js
@@ -141,7 +141,6 @@ export const arrayAsSequence = wrap({
     asSequence: {
         // First priority core converter
         implicit: true,
-        priority: -1000,
         predicate: isArray,
         bounded: () => true,
         unbounded: () => false,

--- a/src/functions/iterableAsSequence.js
+++ b/src/functions/iterableAsSequence.js
@@ -93,7 +93,10 @@ export const iterableAsSequence = wrap({
         // Extremely low priority converter due to how generic it is.
         // Second-last priority of all core converters, before objectAsSequence.
         implicit: true,
-        priority: 800,
+        after: {
+            arrayAsSequence: true,
+            stringAsSequence: true,
+        },
         predicate: isIterable,
         bounded: () => false,
         unbounded: () => false,

--- a/src/functions/objectAsSequence.js
+++ b/src/functions/objectAsSequence.js
@@ -287,8 +287,12 @@ export const objectAsSequence = wrap({
         // Extremely low priority converter due to how generic it is.
         // Last priority of all core converters.
         implicit: false,
-        priority: 1000,
-        predicate: value => isPlainObject(value),
+        after: {
+            arrayAsSequence: true,
+            stringAsSequence: true,
+            iterableAsSequence: true,
+        },
+        predicate: isPlainObject,
         bounded: () => true,
         unbounded: () => false,
     },

--- a/src/functions/stringAsSequence.js
+++ b/src/functions/stringAsSequence.js
@@ -132,7 +132,9 @@ export const stringAsSequence = wrap({
     asSequence: {
         // Comes after only array conversion and before generic iterable conversion.
         implicit: false,
-        priority: -800,
+        after: {
+            arrayAsSequence: true,
+        },
         predicate: isString,
         bounded: () => true,
         unbounded: () => false,


### PR DESCRIPTION
Resolves https://github.com/pineapplemachine/higher/issues/110

Previously, sequence converter priority was determined by numbers. Lower numbers indicated preceding priority. This could become a problem if users wanted to extend sequence conversion implementation for more than a small few other use cases. This changes priority to be determined by before/after indicators instead of a number. This will allow different extensions to be more compatible with one another and with the core library if it is extended.

I couldn't find any particular case which produced bad behavior, but it seems maybe possible that the implementation could fail to find the valid order for some inputs based on the order in which those inputs are given? If so, it may be necessary to expand this implementation to handle such cases.