### PR TITLE
Add consumers and "matches" function utilizing them

### DIFF
--- a/src/consumer/asConsumer.js
+++ b/src/consumer/asConsumer.js
@@ -1,0 +1,79 @@
+import {addConverter} from "../core/addConverter";
+import {lightWrap} from "../core/lightWrap";
+
+import {isConsumer} from "./consumer";
+
+export const consumerConverters = [];
+
+export const asConsumer = lightWrap({
+    summary: "Get a @Converter corresponding to some input.",
+    docs: process.env.NODE_ENV !== "development" ? undefined : {
+        introduced: "higher@1.0.0",
+        expects: (`
+            The function expects one argument of any type.
+        `),
+        returns: (`
+            The function returns a @Consumer object when there was any applicable
+            converter.
+            If no consumer could be acquired for the input, then the function
+            returns #undefined.
+        `),
+        developers: (`
+            Note that every converter that is registered slightly increases the
+            performance impact of calling the function. For low numbers of
+            converters the impact is negligible, but registering a great number
+            of converters may have a noticable impact.
+        `),
+        examples: [
+            "basicUsageArray", "basicUsageString",
+            "basicUsageObject", "basicUsageIterator",
+        ],
+        related: [
+            "validAsConsumer", "isConverter",
+        ],
+    },
+    implementation: function asConsumer(value){
+        if(isConsumer(value)) return value;
+        for(const consumerType of consumerConverters){
+            if(consumerType.converter.predicate(value)){
+                return new consumerType(value);
+            }
+        }
+        return undefined;
+    },
+});
+
+export const addConsumerConverter = lightWrap({
+    summary: "Register a new consumer converter.",
+    docs: process.env.NODE_ENV !== "development" ? undefined : {
+        introduced: "higher@1.0.0",
+    },
+    implementation: function addConsumerConverter(converter){
+        addConverter(converter, consumerConverters);
+    },
+});
+
+export const validAsConsumer = lightWrap({
+    summary: "Get whether a @Converter may be constructed from an input.",
+    docs: process.env.NODE_ENV !== "development" ? undefined : {
+        introduced: "higher@1.0.0",
+        examples: [
+            "basicUsage",
+        ],
+    },
+    implementation: function validAsConsumer(value){
+        if(isConsumer(value)) return true;
+        for(const consumerType of consumerConverters){
+            if(consumerType.converter.predicate(value)){
+                return true;
+            }
+        }
+        return false;
+    },
+    tests: process.env.NODE_ENV !== "development" ? undefined : {
+        "basicUsage": hi => {
+            hi.assert(hi.validAsConsumer([1, 2, 3]));
+            hi.assertNot(hi.validAsConsumer(undefined));
+        },
+    },
+});

--- a/src/consumer/comparisonConsumer.js
+++ b/src/consumer/comparisonConsumer.js
@@ -1,0 +1,46 @@
+import {validAsSequence} from "../core/asSequence";
+import {isEqual} from "../core/isEqual";
+
+import {defineConsumer} from "./defineConsumer";
+
+export const defaultConsumerComparison = isEqual;
+
+export const ComparisonConsumer = defineConsumer({
+    summary: "Match a sequence of elements equal to the corresponding elements of another sequence.",
+    docs: process.env.NODE_ENV !== "development" ? undefined : {
+        introduced: "higher@1.0.0",
+    },
+    converter: {
+        predicate: validAsSequence,
+        after: {
+            PredicateConsumer: true,
+        },
+    },
+    constructor: function ComparisonConsumer(
+        source, compare = undefined, anyFail = undefined
+    ){
+        this.source = source;
+        this.compare = compare || defaultConsumerComparison;
+        this.anyFail = anyFail;
+    },
+    push: function(element){
+        if(!this.anyFail){
+            const match = this.compare(element, this.source.nextFront());
+            if(!match){
+                this.anyFail = true;
+            }
+        }
+    },
+    pushEnd: function(){
+        this.anyFail = this.anyFail || !this.source.done();
+    },
+    done: function(){
+        return this.anyFail || this.source.done();
+    },
+    matched: function(){
+        return !this.anyFail && this.source.done();
+    },
+    copy: function(){
+        return new ComparisonConsumer(this.source, this.compare, this.anyFail);
+    },
+});

--- a/src/consumer/comparisonConsumer.js
+++ b/src/consumer/comparisonConsumer.js
@@ -9,6 +9,12 @@ export const ComparisonConsumer = defineConsumer({
     summary: "Match a sequence of elements equal to the corresponding elements of another sequence.",
     docs: process.env.NODE_ENV !== "development" ? undefined : {
         introduced: "higher@1.0.0",
+        expects: (`
+            The constructor expects a sequence and an optional comparison
+            function as input.
+            When no comparison function was given, @isEqual is used as a
+            default.
+        `),
     },
     converter: {
         predicate: validAsSequence,
@@ -22,10 +28,21 @@ export const ComparisonConsumer = defineConsumer({
         this.source = source;
         this.compare = compare || defaultConsumerComparison;
         this.anyFail = anyFail;
+        if(!source.back){
+            this.pushBack = undefined;
+        }
     },
-    push: function(element){
+    pushFront: function(element){
         if(!this.anyFail){
             const match = this.compare(element, this.source.nextFront());
+            if(!match){
+                this.anyFail = true;
+            }
+        }
+    },
+    pushBack: function(element){
+        if(!this.anyFail){
+            const match = this.compare(element, this.source.nextBack());
             if(!match){
                 this.anyFail = true;
             }

--- a/src/consumer/consumer.js
+++ b/src/consumer/consumer.js
@@ -1,0 +1,41 @@
+import {lightWrap} from "../core/lightWrap";
+
+export const isConsumer = lightWrap({
+    summary: "Determine whether a value is some @Consumer.",
+    docs: process.env.NODE_ENV !== "development" ? undefined : {
+        introduced: "higher@1.0.0",
+        expects: (`
+            The function accepts one argument of any kind.
+        `),
+        returns: (`
+            The function returns true when the input was a @Consumer and false
+            otherwise.
+        `),
+        examples: [
+            "basicUsage",
+        ],
+        related: [
+            "asSequence", "validAsSequence",
+        ],
+    },
+    implementation: function isConsumer(value){
+        return value && value instanceof Consumer;
+    },
+    tests: {
+        "basicUsage": hi => {
+            const consumer = new hi.consumer.PredicateConsumer(i => true);
+            hi.assert(hi.isConsumer(consumer));
+            const predicate = i => false;
+            hi.assertNot(hi.isConsumer(predicate));
+        },
+        "nilInput": hi => {
+            hi.assertNot(hi.isConsumer(null));
+            hi.assertNot(hi.isConsumer(undefined));
+            hi.assertNot(hi.isConsumer(NaN));
+        },
+    },
+});
+
+export const Consumer = function(){};
+
+export default Consumer;

--- a/src/consumer/consumerPool.js
+++ b/src/consumer/consumerPool.js
@@ -1,0 +1,62 @@
+export const ConsumerPool = function(
+    consumer, pool = undefined, anyMatch = undefined, index = undefined
+){
+    this.consumer = consumer;
+    this.pool = pool || [];
+    this.anyMatch = anyMatch;
+    this.index = index || 0;
+};
+
+Object.assign(ConsumerGroup.prototype, {
+    push: function(i){
+        let inactiveCount = 0;
+        for(const consumer of this.pool){
+            if(consumer.done()){
+                inactiveCount++;
+            }else{
+                consumer.push(i);
+                if(consumer.done() && consumer.match()){
+                    this.anyMatch = this.anyMatch || consumer;
+                }
+            }
+        }
+        if(inactiveCount >= 32 && inactiveCount >= this.pool.length / 2){
+            this.flush();
+        }
+        if(!this.anyMatch){
+            const newConsumer = this.consumer.copy();
+            newConsumer.poolStartIndex = this.index;
+            newConsumer.push(i);
+            if(!newConsumer.done()){
+                this.pool.push(newConsumer);
+            }else if(newConsumer.matched()){
+                this.anyMatch = newConsumer;
+            }
+        }
+        this.index++;
+    },
+    pushEnd: function(){
+        for(const consumer of this.pool){
+            if(!consumer.done()){
+                consumer.pushEnd();
+                if(consumer.done() && consumer.match()){
+                    this.anyMatch = this.anyMatch || consumer;
+                }
+            }
+        }
+    },
+    matched: function(){
+        return this.anyMatch;
+    },
+    flush: function(i){
+        const newPool = [];
+        for(const consumer of this.pool){
+            if(!consumer.noMatch()){
+                newPool.push(consumer);
+            }
+        }
+        this.pool = newPool;
+    },
+});
+
+export default ConsumerPool;

--- a/src/consumer/defineConsumer.js
+++ b/src/consumer/defineConsumer.js
@@ -1,0 +1,34 @@
+import {lightWrap} from "../core/lightWrap";
+
+import {addConsumerConverter} from "./asConsumer";
+import {Consumer} from "./consumer";
+
+export const consumerTypes = {};
+
+// TODO: Thoroughly document consumer type creation somewhere
+export const defineConsumer = lightWrap({
+    summary: "Extend the @Consumer prototype.",
+    docs: process.env.NODE_ENV !== "development" ? undefined : {
+        introduced: "higher@1.0.0",
+        expects: (`
+            The function expects an object whose attributes will be assigned
+            to the resulting @Consumer type.
+        `),
+        returns: (`
+            The function returns the constructor for the new @Consumer type.
+        `),
+    },
+    implementation: function defineConsumer(attributes){
+        const constructor = attributes.constructor;
+        constructor.prototype = Object.create(Consumer.prototype);
+        Object.assign(constructor, attributes);
+        Object.assign(constructor.prototype, attributes);
+        consumerTypes[constructor.name] = constructor;
+        if(constructor.converter){
+            addConsumerConverter(constructor);
+        }
+        return constructor;
+    },
+});
+
+export default defineConsumer;

--- a/src/consumer/expectingConsumer.js
+++ b/src/consumer/expectingConsumer.js
@@ -1,0 +1,18 @@
+import {Expecting} from "../core/expecting";
+
+import {asConsumer} from "./asConsumer";
+
+export const expectingConsumer = Expecting({
+    type: "consumer",
+    article: "a",
+    singular: "consumer",
+    plural: "consumers",
+    transforms: true,
+    validate: value => {
+        const converter = asConsumer(value);
+        if(!converter) throw new Error();
+        return converter;
+    },
+});
+
+export default expectingConsumer;

--- a/src/consumer/predicateConsumer.js
+++ b/src/consumer/predicateConsumer.js
@@ -31,7 +31,13 @@ export const PredicateConsumer = defineConsumer({
         this.lastMatch = lastMatch;
         this.anyMatch = anyMatch;
     },
-    push: function(element){
+    pushFront: function(element){
+        this.lastMatch = this.predicate(element);
+        if(this.lastMatch){
+            this.anyMatch = this.lastMatch;
+        }
+    },
+    pushBack: function(element){
         this.lastMatch = this.predicate(element);
         if(this.lastMatch){
             this.anyMatch = this.lastMatch;

--- a/src/consumer/predicateConsumer.js
+++ b/src/consumer/predicateConsumer.js
@@ -1,0 +1,54 @@
+import {isFunction} from "../core/types";
+
+import {defineConsumer} from "./defineConsumer";
+
+export const PredicateConsumer = defineConsumer({
+    summary: "Match a sequence of elements all satisfying a predicate.",
+    docs: process.env.NODE_ENV !== "development" ? undefined : {
+        introduced: "higher@1.0.0",
+        expects: (`
+            The constructor expects a predicate function as its single argument.
+        `),
+    },
+    tests: process.env.NODE_ENV !== "development" ? undefined : {
+        "numberInputs": hi => {
+            const even = new PredicateConsumer(n => n % 2 === 0);
+            hi.assert(hi.match([0]), even);
+            hi.assert(hi.match([0, 2, 4, 6, 8], even));
+            hi.assertNot(hi.emptySequence().match(even));
+            hi.assertNot(hi.match([1], even));
+            hi.assertNot(hi.match([1, 2, 3, 4], even));
+            hi.assertNot(hi.match([0, 2, 5, 8], even));
+        },
+    },
+    converter: {
+        predicate: isFunction,
+    },
+    constructor: function PredicateConsumer(
+        predicate, lastMatch = undefined, anyMatch = undefined
+    ){
+        this.predicate = predicate;
+        this.lastMatch = lastMatch;
+        this.anyMatch = anyMatch;
+    },
+    push: function(element){
+        this.lastMatch = this.predicate(element);
+        if(this.lastMatch){
+            this.anyMatch = this.lastMatch;
+        }
+    },
+    pushEnd: function(){
+        this.lastMatch = false;
+    },
+    done: function(){
+        return !this.lastMatch;
+    },
+    match: function(){
+        return this.anyMatch;
+    },
+    copy: function(){
+        return new PredicateConsumer(
+            this.predicate, this.lastMatch, this.anyMatch
+        );
+    },
+});

--- a/src/core/addConverter.js
+++ b/src/core/addConverter.js
@@ -1,0 +1,41 @@
+import {lightWrap} from "./lightWrap";
+
+// Implementation shared by addSequenceConverter and addConsumerConverter.
+export const addConverter = lightWrap({
+    internal: true,
+    summary: "Register a new object in some list of objects.",
+    docs: process.env.NODE_ENV !== "development" ? undefined : {
+        introduced: "higher@1.0.0",
+    },
+    implementation: function addConverter(object, list){
+        let lowest = undefined;
+        let highest = undefined;
+        for(let i = 0; i < list.length; i++){
+            const existing = list[i];
+            if(
+                (object.converter.after && object.converter.after[existing.name]) ||
+                (existing.converter.before && existing.converter.before[object.name])
+            ){
+                lowest = i + 1;
+            }
+            if(highest === undefined && (
+                (object.converter.before && object.converter.before[existing.name]) ||
+                (existing.converter.after && existing.converter.after[object.name])
+            )){
+                highest = i;
+            }
+        }
+        if(highest === undefined){
+            list.push(object);
+        }else if(lowest === undefined || highest >= lowest){
+            list.splice(highest, 0, object);
+        }else{
+            throw new Exception(
+                `Unable to place object ${object.name} because ` +
+                "of conflicting ordering information."
+            );
+        }
+    },
+});
+
+export default addConverter;

--- a/src/core/defineSequence.js
+++ b/src/core/defineSequence.js
@@ -46,27 +46,27 @@ const sequenceTypeAttributes = {
     index: {
         native: "nativeIndex",
         constructor: false,
-        prototype: true,
+        prototype: false,
     },
     indexNegative: {
         native: "nativeIndexNegative",
         constructor: false,
-        prototype: true,
+        prototype: false,
     },
     slice: {
         native: "nativeSlice",
         constructor: false,
-        prototype: true,
+        prototype: false,
     },
     sliceNegative: {
         native: "nativeSliceNegative",
         constructor: false,
-        prototype: true,
+        prototype: false,
     },
     sliceMixed: {
         native: "nativeSliceMixed",
         constructor: false,
-        prototype: true,
+        prototype: false,
     },
     has: {
         native: "nativeHas",
@@ -118,7 +118,7 @@ const sequenceTypeAttributes = {
     },
     supportDescription: {
         constructor: true,
-        clean: true,
+        cleanString: true,
     },
 };
 
@@ -140,85 +140,33 @@ export const defineSequence = lightWrap({
         };
         for(const attributeName in attributes){
             const attribute = attributes[attributeName];
-            if(attributeName === "done"){
-                constructor.nativeDone = attribute;
-                constructor.prototype.nativeDone = attribute;
-                constructor.prototype.done = attribute;
-            }else if(attributeName === "length"){
-                constructor.nativeLength = attribute;
-                constructor.prototype.nativeLength = attribute;
-                constructor.prototype.length = attribute;
-            }else if(attributeName === "front"){
-                constructor.nativeFront = attribute;
-                constructor.prototype.nativeFront = attribute;
-                constructor.prototype.front = attribute;
-            }else if(attributeName === "popFront"){
-                constructor.nativePopFront = attribute;
-                constructor.prototype.nativePopFront = attribute;
-                constructor.prototype.popFront = attribute;
-            }else if(attributeName === "back"){
-                constructor.nativeBack = attribute;
-                constructor.prototype.nativeBack = attribute;
-                constructor.prototype.back = attribute;
-            }else if(attributeName === "popBack"){
-                constructor.nativePopBack = attribute;
-                constructor.prototype.nativePopBack = attribute;
-                constructor.prototype.popBack = attribute;
-            }else if(attributeName === "index"){
-                constructor.nativeIndex = attribute;
-                constructor.prototype.nativeIndex = attribute;
-            }else if(attributeName === "indexNegative"){
-                constructor.nativeIndexNegative = attribute;
-                constructor.prototype.nativeIndexNegative = attribute;
-            }else if(attributeName === "slice"){
-                constructor.nativeSlice = attribute;
-                constructor.prototype.nativeSlice = attribute;
-            }else if(attributeName === "sliceNegative"){
-                constructor.nativeSliceNegative = attribute;
-                constructor.prototype.nativeSliceNegative = attribute;
-            }else if(attributeName === "sliceMixed"){
-                constructor.nativeSliceMixed = attribute;
-                constructor.prototype.nativeSliceMixed = attribute;
-            }else if(attributeName === "has"){
-                constructor.nativeHas = attribute;
-                constructor.prototype.nativeHas = attribute;
-                constructor.prototype.has = attribute;
-            }else if(attributeName === "get"){
-                constructor.nativeGet = attribute;
-                constructor.prototype.nativeGet = attribute;
-                constructor.prototype.get = attribute;
-            }else if(attributeName === "copy"){
-                constructor.nativeCopy = attribute;
-                constructor.prototype.nativeCopy = attribute;
-                constructor.prototype.copy = attribute;
-            }else if(attributeName === "overrides"){
-                constructor.prototype.overrides = attribute;
-                constructor.overrides = attribute;
-            }else if(
-                attributeName === "supportRequired" ||
-                attributeName === "supportsWith"
-            ){
-                if(isArray(attribute)){
-                    const obj = {};
-                    for(const methodName of attribute) obj[methodName] = "any";
-                    constructor[attributeName] = obj;
-                }else{
-                    constructor[attributeName] = attribute;
-                }
-            }else if(
-                attributeName === "summary" ||
-                attributeName === "docs" ||
-                attributeName === "tests" ||
-                attributeName === "getSequence" ||
-                attributeName === "supportsAlways" ||
-                attributeName === "supportComplicated" ||
-                attributeName === "converter"
-            ){
-                constructor[attributeName] = attribute;
-            }else if(attributeName === "supportDescription"){
-                constructor[attributeName] = cleanString(attribute);
-            }else{
+            const info = sequenceTypeAttributes[attributeName];
+            let value;
+            if(!info){
                 constructor.prototype[attributeName] = attribute;
+            }else{
+                if(info.supportObject){
+                    if(isArray(attribute)){
+                        value = {};
+                        for(const methodName of attribute) value[methodName] = "any";
+                    }else{
+                        value = attribute;
+                    }
+                }else if(info.cleanString){
+                    value = cleanString(attribute);
+                }else{
+                    value = attribute;
+                }
+                if(info.native){
+                    constructor[info.native] = value;
+                    constructor.prototype[info.native] = value;
+                }
+                if(info.constructor){
+                    constructor[attributeName] = value;
+                }
+                if(info.prototype){
+                    constructor.prototype[attributeName] = value;
+                }
             }
         }
         wrapSequenceOverrides(constructor, attributes.overrides);

--- a/src/core/defineSequence.js
+++ b/src/core/defineSequence.js
@@ -1,3 +1,4 @@
+import {addSequenceConverter} from "./asSequence";
 import {callAsync} from "./callAsync";
 import {constants} from "./constants";
 import {normalizeExpecting} from "./expecting";
@@ -7,12 +8,119 @@ import {appliedSequenceSupports} from "./sequence";
 import {isArray, isNumber} from "./types";
 import {getWrappedFunction, getWrappedFunctionAsync} from "./wrapFunction";
 
-import {ArgumentsError} from "../errors/ArgumentsError";
-import {NotBoundedError} from "../errors/NotBoundedError";
-
 import {cleanDocs, cleanString} from "../docs/cleanString";
 
 export const sequenceTypes = {};
+
+const sequenceTypeAttributes = {
+    done: {
+        native: "nativeDone",
+        constructor: false,
+        prototype: true,
+    },
+    length: {
+        native: "nativeLength",
+        constructor: false,
+        prototype: true,
+    },
+    front: {
+        native: "nativeFront",
+        constructor: false,
+        prototype: true,
+    },
+    popFront: {
+        native: "nativePopFront",
+        constructor: false,
+        prototype: true,
+    },
+    back: {
+        native: "nativeBack",
+        constructor: false,
+        prototype: true,
+    },
+    popBack: {
+        native: "nativePopBack",
+        constructor: false,
+        prototype: true,
+    },
+    index: {
+        native: "nativeIndex",
+        constructor: false,
+        prototype: true,
+    },
+    indexNegative: {
+        native: "nativeIndexNegative",
+        constructor: false,
+        prototype: true,
+    },
+    slice: {
+        native: "nativeSlice",
+        constructor: false,
+        prototype: true,
+    },
+    sliceNegative: {
+        native: "nativeSliceNegative",
+        constructor: false,
+        prototype: true,
+    },
+    sliceMixed: {
+        native: "nativeSliceMixed",
+        constructor: false,
+        prototype: true,
+    },
+    has: {
+        native: "nativeHas",
+        constructor: false,
+        prototype: true,
+    },
+    get: {
+        native: "nativeGet",
+        constructor: false,
+        prototype: true,
+    },
+    copy: {
+        native: "nativeCopy",
+        constructor: false,
+        prototype: true,
+    },
+    overrides: {
+        constructor: true,
+        prototype: true,
+    },
+    supportRequired: {
+        constructor: true,
+        supportObject: true,
+    },
+    supportsWith: {
+        constructor: true,
+        supportObject: true,
+    },
+    summary: {
+        constructor: true,
+    },
+    docs: {
+        constructor: true,
+    },
+    tests: {
+        constructor: true,
+    },
+    getSequence: {
+        constructor: true,
+    },
+    supportsAlways: {
+        constructor: true,
+    },
+    supportComplicated: {
+        constructor: true,
+    },
+    converter: {
+        constructor: true,
+    },
+    supportDescription: {
+        constructor: true,
+        clean: true,
+    },
+};
 
 // TODO: Thoroughly document sequence type creation somewhere
 export const defineSequence = lightWrap({
@@ -103,7 +211,8 @@ export const defineSequence = lightWrap({
                 attributeName === "tests" ||
                 attributeName === "getSequence" ||
                 attributeName === "supportsAlways" ||
-                attributeName === "supportComplicated"
+                attributeName === "supportComplicated" ||
+                attributeName === "converter"
             ){
                 constructor[attributeName] = attribute;
             }else if(attributeName === "supportDescription"){
@@ -115,6 +224,9 @@ export const defineSequence = lightWrap({
         wrapSequenceOverrides(constructor, attributes.overrides);
         constructor.test = sequenceTestRunner(constructor);
         sequenceTypes[constructor.name] = constructor;
+        if(constructor.converter){
+            addSequenceConverter(constructor);
+        }
         return constructor;
     },
 });

--- a/src/core/expecting.js
+++ b/src/core/expecting.js
@@ -1,4 +1,4 @@
-import {addSequenceConverter, asSequence, validAsSequence} from "./asSequence";
+import {asSequence, validAsSequence} from "./asSequence";
 import {callAsync} from "./callAsync";
 import {constants} from "./constants";
 import {joinSeries} from "./english";

--- a/src/core/sequence.js
+++ b/src/core/sequence.js
@@ -1,8 +1,4 @@
 import {lightWrap} from "./lightWrap";
-import {isNumber} from "./types";
-
-import {BoundsUnknownError} from "../errors/BoundsUnknownError";
-import {NotBoundedError} from "../errors/NotBoundedError";
 
 export const isSequence = lightWrap({
     summary: "Determine whether a value is some @Sequence.",
@@ -23,7 +19,7 @@ export const isSequence = lightWrap({
         ],
     },
     implementation: function isSequence(value){
-        return value instanceof Sequence;
+        return value && value instanceof Sequence;
     },
     tests: {
         "basicUsage": hi => {
@@ -31,6 +27,11 @@ export const isSequence = lightWrap({
             hi.assert(hi.isSequence(seq));
             const array = [1, 2, 3, 4];
             hi.assertNot(hi.isSequence(array));
+        },
+        "nilInput": hi => {
+            hi.assertNot(hi.isSequence(null));
+            hi.assertNot(hi.isSequence(undefined));
+            hi.assertNot(hi.isSequence(NaN));
         },
     },
 });

--- a/src/core/wrap.js
+++ b/src/core/wrap.js
@@ -1,4 +1,3 @@
-import {addSequenceConverter} from "./asSequence";
 import {expecting, Expecting, normalizeExpecting} from "./expecting";
 import {lightWrap, wrappedTestRunner} from "./lightWrap";
 import {partialLeft, partialRight} from "./partial";
@@ -64,14 +63,6 @@ export const wrap = lightWrap({
             fancy.method.implementation = info.methodImplementation || info.implementation;
             if(info.async) fancy.method.async = getWrappedFunctionAsync(fancy.method);
             attachSequenceMethods(fancy);
-        }
-        if(info.asSequence){
-            const converterData = {
-                name: fancy.name,
-                transform: info.implementation
-            };
-            const converter = Object.assign(converterData, info.asSequence);
-            addSequenceConverter(converter);
         }
         if(process.env.NODE_ENV === "development"){
             fancy.docs = cleanDocs(info.docs);

--- a/src/functions/arrayAsSequence.js
+++ b/src/functions/arrayAsSequence.js
@@ -47,6 +47,12 @@ export const ArraySequence = defineSequence({
         hi => new ArraySequence([0, 1, 2, 3, 4, 5, 6]),
         hi => new ArraySequence([[0, 1], [1, 2]]),
     ],
+    converter: {
+        implicit: true,
+        predicate: isArray,
+        bounded: () => true,
+        unbounded: () => false,
+    },
     constructor: function ArraySequence(
         source, lowIndex = undefined, highIndex = undefined,
         frontIndex = undefined, backIndex = undefined
@@ -138,13 +144,6 @@ export const arrayAsSequence = wrap({
     },
     attachSequence: false,
     async: false,
-    asSequence: {
-        // First priority core converter
-        implicit: true,
-        predicate: isArray,
-        bounded: () => true,
-        unbounded: () => false,
-    },
     arguments: {
         one: wrap.expecting.array
     },

--- a/src/functions/iterableAsSequence.js
+++ b/src/functions/iterableAsSequence.js
@@ -28,6 +28,16 @@ export const IterableSequence = defineSequence({
             hi.assertEqual(acc, [0, 1, 2]);
         },
     },
+    converter: {
+        implicit: true,
+        after: {
+            arrayAsSequence: true,
+            stringAsSequence: true,
+        },
+        predicate: isIterable,
+        bounded: () => false,
+        unbounded: () => false,
+    },
     constructor: function IterableSequence(
         source, first = true, item = undefined
     ){
@@ -89,18 +99,6 @@ export const iterableAsSequence = wrap({
     },
     attachSequence: false,
     async: false,
-    asSequence: {
-        // Extremely low priority converter due to how generic it is.
-        // Second-last priority of all core converters, before objectAsSequence.
-        implicit: true,
-        after: {
-            arrayAsSequence: true,
-            stringAsSequence: true,
-        },
-        predicate: isIterable,
-        bounded: () => false,
-        unbounded: () => false,
-    },
     arguments: {
         one: wrap.expecting.iterable,
     },

--- a/src/functions/matches.js
+++ b/src/functions/matches.js
@@ -36,7 +36,7 @@ export const matches = wrap({
     implementation: function matches(source, consumer){
         const currentConsumer = consumer.copy();
         for(const element of source){
-            currentConsumer.push(element);
+            currentConsumer.pushFront(element);
             if(currentConsumer.done()){
                 return false;
             }

--- a/src/functions/matches.js
+++ b/src/functions/matches.js
@@ -1,0 +1,59 @@
+import {wrap} from "../core/wrap";
+
+import {expectingConsumer} from "../consumer/expectingConsumer";
+
+export const matches = wrap({
+    name: "matches",
+    summary: "Check if a consumer matches a given sequence.",
+    docs: process.env.NODE_ENV !== "development" ? undefined : {
+        introduced: "higher@1.0.0",
+        expects: (`
+            The function expects a sequence and a consumer as input.
+        `),
+        returns: (`
+            The function returns a truthy value when the consumer matched the
+            complete input sequence and a falsey value when it did not.
+        `),
+        warnings: (`
+            This function will produce an infinite loop when the consumer
+            matches an infinite number of elements in an unbounded input
+            sequence.
+        `),
+        returnType: "boolean",
+        examples: [
+            "basicUsage",
+        ],
+        related: [
+            "startsWith",
+            "endsWidth",
+        ],
+    },
+    attachSequence: true,
+    async: true,
+    arguments: {
+        ordered: [wrap.expecting.sequence, expectingConsumer],
+    },
+    implementation: function matches(source, consumer){
+        const currentConsumer = consumer.copy();
+        for(const element of source){
+            currentConsumer.push(element);
+            if(currentConsumer.done()){
+                return false;
+            }
+        }
+        currentConsumer.pushEnd();
+        if(currentConsumer.done()){
+            return currentConsumer.match();
+        }
+    },
+    tests: process.env.NODE_ENV !== "development" ? undefined : {
+        "basicUsage": hi => {
+            const isSpace = i => i === " ";
+            const spacePattern = new hi.consumer.PredicateConsumer(isSpace);
+            hi.assert(hi("    ").matches(spacePattern));
+            hi.assertNot(hi("hello").matches(spacePattern));
+        },
+    },
+});
+
+export default matches;

--- a/src/functions/objectAsSequence.js
+++ b/src/functions/objectAsSequence.js
@@ -115,6 +115,17 @@ export const ObjectSequence = defineSequence({
         hi => new ObjectSequence({a: 0, b: 1}),
         hi => new ObjectSequence({x: "hello", y: "world", z: "how", w: "do"}),
     ],
+    converter: {
+        implicit: false,
+        after: {
+            arrayAsSequence: true,
+            stringAsSequence: true,
+            iterableAsSequence: true,
+        },
+        predicate: isPlainObject,
+        bounded: () => true,
+        unbounded: () => false,
+    },
     constructor: function ObjectSequence(
         source, objectKeys = undefined, lowIndex = undefined,
         highIndex = undefined, frontIndex = undefined, backIndex = undefined
@@ -283,19 +294,6 @@ export const objectAsSequence = wrap({
     summary: "Get a sequence enumerating the key, value pairs of an object.",
     attachSequence: false,
     async: false,
-    asSequence: {
-        // Extremely low priority converter due to how generic it is.
-        // Last priority of all core converters.
-        implicit: false,
-        after: {
-            arrayAsSequence: true,
-            stringAsSequence: true,
-            iterableAsSequence: true,
-        },
-        predicate: isPlainObject,
-        bounded: () => true,
-        unbounded: () => false,
-    },
     arguments: {
         one: wrap.expecting.object
     },

--- a/src/functions/stringAsSequence.js
+++ b/src/functions/stringAsSequence.js
@@ -40,6 +40,15 @@ export const StringSequence = defineSequence({
             hi.assert(seq.slice(1, 5).string() === "ello");
         },
     },
+    converter: {
+        implicit: false,
+        after: {
+            arrayAsSequence: true,
+        },
+        predicate: isString,
+        bounded: () => true,
+        unbounded: () => false,
+    },
     constructor: function StringSequence(
         source, lowIndex = undefined, highIndex = undefined,
         frontIndex = undefined, backIndex = undefined
@@ -129,16 +138,6 @@ export const stringAsSequence = wrap({
     },
     attachSequence: false,
     async: false,
-    asSequence: {
-        // Comes after only array conversion and before generic iterable conversion.
-        implicit: false,
-        after: {
-            arrayAsSequence: true,
-        },
-        predicate: isString,
-        bounded: () => true,
-        unbounded: () => false,
-    },
     arguments: {
         one: wrap.expecting.anything
     },

--- a/src/higher.js
+++ b/src/higher.js
@@ -101,6 +101,22 @@ if(process.env.NODE_ENV === "development") hi.test = lightWrap({
     },
 });
 
+// consumer/asConsumer
+import {asConsumer} from "./consumer/asConsumer"; hi.register(asConsumer);
+import {addConsumerConverter} from "./consumer/asConsumer"; hi.register(addConsumerConverter);
+import {validAsConsumer} from "./consumer/asConsumer"; hi.register(validAsConsumer);
+import {consumerConverters} from "./consumer/asConsumer"; hi.consumerConverters = consumerConverters;
+// consumer/consumer
+import {Consumer} from "./consumer/consumer"; hi.Consumer = Consumer;
+import {isConsumer} from "./consumer/consumer"; hi.register(isConsumer);
+// consumer/defineConsumer
+import {consumerTypes} from "./consumer/defineConsumer"; hi.consumer = consumerTypes;
+import {defineConsumer} from "./consumer/defineConsumer"; hi.register(defineConsumer);
+
+// Core consumer types
+import {PredicateConsumer} from "./consumer/predicateConsumer";
+import {ComparisonConsumer} from "./consumer/comparisonConsumer";
+
 // core/asSequence
 import {asSequence} from "./core/asSequence"; hi.register(asSequence);
 import {asImplicitSequence} from "./core/asSequence"; hi.register(asImplicitSequence);
@@ -109,6 +125,7 @@ import {validAsSequence} from "./core/asSequence"; hi.register(validAsSequence);
 import {validAsImplicitSequence} from "./core/asSequence"; hi.register(validAsImplicitSequence);
 import {validAsBoundedSequence} from "./core/asSequence"; hi.register(validAsBoundedSequence);
 import {validAsUnboundedSequence} from "./core/asSequence"; hi.register(validAsUnboundedSequence);
+import {sequenceConverters} from "./core/asSequence"; hi.sequenceConverters = sequenceConverters;
 // core/assert
 import {assert} from "./core/assert"; hi.register(assert);
 import {assertNot} from "./core/assert"; hi.register(assertNot);
@@ -140,8 +157,8 @@ import {sequencesEqual} from "./core/isEqual"; hi.register(sequencesEqual);
 import {stringsEqual} from "./core/isEqual"; hi.register(stringsEqual);
 import {objectsEqual} from "./core/isEqual"; hi.register(objectsEqual);
 import {valuesEqual} from "./core/isEqual"; hi.register(valuesEqual);
-// core/lightWrap
-/* imported above */ hi.register(lightWrap);
+// core/lightWrap (imported above)
+hi.register(lightWrap);
 // core/partial
 import {partial} from "./core/partial"; hi.register(partial);
 import {partialRight} from "./core/partial"; hi.register(partialRight);
@@ -254,6 +271,7 @@ import {lexOrder} from "./functions/lexOrder"; hi.register(lexOrder);
 import {limit} from "./functions/limit"; hi.register(limit);
 import {map} from "./functions/map"; hi.register(map);
 import {mapIndex} from "./functions/mapIndex"; hi.register(mapIndex);
+import {matches} from "./functions/matches"; hi.register(matches);
 import {max} from "./functions/max"; hi.register(max);
 import {min} from "./functions/min"; hi.register(min);
 import {negate} from "./functions/negate"; hi.register(negate);


### PR DESCRIPTION
Resolves https://github.com/pineapplemachine/higher/issues/99 - see that issue for more details about consumers as implemented in this branch.

Adds a `matches` function for checking if a sequence completely matches a consumer.

Throwaway thought: Should consumers be renamed to patterns before release?